### PR TITLE
Use newer location for migratecli

### DIFF
--- a/scripts/migrate-db.sh
+++ b/scripts/migrate-db.sh
@@ -13,13 +13,10 @@ echo "Running migrations"
 # When this script is run inside the `pulumi/migrations` container,
 # this tool is pre-installed as part of creating the container image.
 which migratecli >/dev/null || {
-    echo "migratecli tool not found in the PATH. Will install it now..."
-    # Install the migrate tool. Use `go build -o` so we can name the binary
-    # `migratecli` instead of the much less useful `cli`.
-    go get -u -d github.com/mattes/migrate/cli github.com/go-sql-driver/mysql
+    echo "Building 'migratecli' from source."
+    GO111MODULE=off go get -u -d github.com/golang-migrate/migrate/cmd/migrate github.com/go-sql-driver/mysql
     INSTALL_DEST=${GOBIN:-$(go env GOPATH)/bin}
-    go build -tags mysql -o "${INSTALL_DEST}/migratecli" github.com/mattes/migrate/cli
-    echo "Successfully installed migratecli"
+    GO111MODULE=off go build -tags mysql -o "${INSTALL_DEST}/migratecli" github.com/golang-migrate/migrate/cmd/migrate
 
     # Ensure the version we built is on the PATH for the rest of this script
     export PATH="${INSTALL_DEST}:${PATH}"


### PR DESCRIPTION
I'm working on upgrading `pulumi-service` to use Golang v1.13 (https://github.com/pulumi/pulumi-service/pull/5107), and that means shaking out all sorts of issues with the toolchain. And part of that means upgrading the `migratecli` tool we use for running database migrations, since newer versions of Go no longer accept the URI we pass for database connections.

```
[665.691] Successfully installed migratecli
1826error: parse mysql://root:test@tcp(localhost:3306)/pulumi: invalid port ":3306)" after host
```

After upgrading the `migratecli` tool to use its new source location (https://github.com/golang-migrate/migrate/cmd/migrate) this seem to be working just fine in the `pulumi-service` repo. However, since we run tests via the `pulumi-ee` folder, I guess we need to make the same change here too?

Does this make sense? And does this look right the right solution?