### PR TITLE
Enable configurable TLS for migrations

### DIFF
--- a/scripts/migrate-db.sh
+++ b/scripts/migrate-db.sh
@@ -43,9 +43,9 @@ fi
 
 DB_QUERY_STRING=
 # Check to see if we should connect to the database using TLS. We do this by checking to see if the DATABASE_CA_CERTIFICATE
-# environment variable is set. If it is we assume the user would like to connect via tls using the provided CA certificate.
+# environment variable is set. If it is we assume the user would like to connect via TLS using the provided CA certificate.
 # This environment variable needs to be set to the value of the certificate and not a filepath. This was done this way in
-# order to be consistent with the way the database certificates are passed into the aAPI service container, i.e. the value
+# order to be consistent with the way the database certificates are passed into the API service container, i.e. the value
 # of the cert not the file path. As now this relies on a fork of the golang-migrate tool - github.com/pulumi/golang-migrate
 # that we made to put in a fix to enable this functionality. We will attempt to get the fix merged to the upstream repo in
 # the future.


### PR DESCRIPTION
This PR adjust the migrate-db script which is run by our docker migrations container, to accept an environment variable to configure TLS. The environment variable is `DATABASE_CA_CERTIFICATE`, which takes the value of the database certificate. I did it this way to make consistent with teh way the `DATABASE_CA_CERTIFICATE` variable is being passed into the API service container.