### PR TITLE
Update GitHub workflow for releases to zip files individually.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         prerelease: false
 
     - name:
-      run: zip pulumi-ee.zip **/*.*
+      run: zip pulumi-ee.zip README.md *.env *.yml all-in-one/**/* scripts/**/*
 
     - name: Upload Release Asset
       id: upload-release-asset


### PR DESCRIPTION
For some reason running `zip pulumi-ee.zip **/*` does the thing I expect it to on my mac, but not in GitHub Actions. It seems to exclude the files in the root folder. So I changed the `zip` command to add files explicitly.