### PR TITLE
Allow skipping creation of pulumi_service passwordless db user

### DIFF
--- a/scripts/migrate-db.sh
+++ b/scripts/migrate-db.sh
@@ -84,8 +84,8 @@ fi
 
 # Force the migration to 1 if the option to skip creation of the
 # pulumi_service DB user is set.
-if [ -n "${SKIP_CREATE_PULUMI_SERVICE_DB_USER:-}" ]; then
-    echo "Skipping the first migration script"
+if [ -n "${SKIP_CREATE_DB_USER:-}" ]; then
+    echo "NOTE: Skipping the first migration script. You will need to set the PULUMI_DATABASE_USER_NAME and PULUMI_DATABASE_USER_PASSWORD environment variables in the API container, to specify a custom database user name and password for your service instance."
     migratecli -path "${MIGRATIONS_DIR}" -database "${DB_CONNECTION_STRING}" force 1
 fi
 


### PR DESCRIPTION
Part of fixing https://github.com/pulumi/pulumi-service/issues/7026.

Here's what a migration with the new option to skip the first migration looks like:

```
pulumi-service on  master [!] via 🐹 v1.16.4 on ☁️  us-west-2 took 7s 
❯ export SKIP_CREATE_PULUMI_SERVICE_DB_USER=true

pulumi-service on  master [!] via 🐹 v1.16.4 on ☁️  us-west-2 
❯ MYSQL_ROOT_PASSWORD=test ./scripts/test-db-local.sh                 
Error response from daemon: network with name pulumi-ee already exists
Starting a new local MySQL container
~/go/src/github.com/pulumi/pulumi-service/pulumi-ee ~/go/src/github.com/pulumi/pulumi-service
pulumi-ee network exists already
MySQL container ID: d5de44a5fe9b
    to kill: docker kill d5de44a5fe9b
Waiting for MySQL to come alive ...
mysqld is alive
MySQL is running!
Running migrations
Force the schema migrations version to 1
2/u create_users_table (57.995498ms)
3/u create_orgs_table (117.353539ms)
4/u create_clouds_table (180.524387ms)
5/u create_programs_table (239.734739ms)
6/u orgs_add_default_cloud (317.710986ms)
7/u add_site_admin (390.080021ms)
8/u add_cloud_settings (482.450502ms)
9/u add_cloud_flags (555.248171ms)
10/u add_events_table (932.56864ms)
11/u add_program_updates_table (1.014385401s)
12/u remove_cloud_ep_constraint (1.080692271s)
13/u create_stacks_table (1.080402233s)
14/u create_updates_table (1.132538678s)
15/u stacks_add_active_update_constraint (1.164641926s)
16/u expand_program_updates_table (1.181429749s)
17/u updates_remove_sha256 (1.177709538s)
18/u create_update_logs_table (1.169711204s)
...
...
Database migrations completed!
```