### PR TITLE
Fix bug that would reset the migration version always to 1 when SKIP_CREATE_DB_USER is set

### DIFF
--- a/scripts/migrate-db.sh
+++ b/scripts/migrate-db.sh
@@ -96,8 +96,7 @@ if [ -n "${SKIP_CREATE_DB_USER:-}" ]; then
     # the output alone is not enough.
     current_version=$(migratecli -path "${MIGRATIONS_DIR}" -database "${DB_CONNECTION_STRING}" version 2>&1) || {
         # Skip the first migration script only if the error is because there isn't a previous
-        # migration. We do a regexp search here for the string "no migration". Hence, the use
-        # of =~.
+        # migration. We do a regexp search here for the string "no migration".
         if [[ "${current_version}" == *"no migration"* ]]; then
             echo "Fresh DB instance"
             skip_first_migration


### PR DESCRIPTION
Part of pulumi/pulumi-service#7080

```
pulumi-service on  praneetloke/7080-bump-pulumi-ee [$] via 🐹 v1.16.4 on ☁️  us-west-2 
❯ export MYSQL_DATA_PATH="${PULUMI_DATA_PATH}/mysql_temp"

pulumi-service on  praneetloke/7080-bump-pulumi-ee [$] via 🐹 v1.16.4 on ☁️  us-west-2 
❯ export SKIP_CREATE_DB_USER=true                        

pulumi-service on  praneetloke/7080-bump-pulumi-ee [$] via 🐹 v1.16.4 on ☁️  us-west-2 
❯ MYSQL_ROOT_PASSWORD=test ./scripts/test-db-local.sh
Error response from daemon: network with name pulumi-ee already exists
Starting a new local MySQL container
~/go/src/github.com/pulumi/pulumi-service/pulumi-ee ~/go/src/github.com/pulumi/pulumi-service
pulumi-ee network exists already
MySQL container ID: ddb37ed7ee2b10fef34555ddbbde4ce688cc390d5b92acfc9b5e425229134080
    to kill: docker kill ddb37ed7ee2b10fef34555ddbbde4ce688cc390d5b92acfc9b5e425229134080
Waiting for MySQL to come alive ...
mysqld is alive
MySQL is running!
Running migrations
NOTE: Skipping the first migration script. You will need to set the PULUMI_DATABASE_USER_NAME and PULUMI_DATABASE_USER_PASSWORD environment variables in the API container, to specify a custom database user name and password for your service instance.
2/u create_users_table (40.17432ms)
3/u create_orgs_table (79.888466ms)
4/u create_clouds_table (123.650792ms)
5/u create_programs_table (168.327425ms)
6/u orgs_add_default_cloud (225.5935ms)
7/u add_site_admin (277.724048ms)
8/u add_cloud_settings (347.223261ms)
9/u add_cloud_flags (401.669292ms)
10/u add_events_table (683.610743ms)
11/u add_program_updates_table (752.992722ms)
12/u remove_cloud_ep_constraint (796.980171ms)
13/u create_stacks_table (799.618375ms)
14/u create_updates_table (842.976902ms)
15/u stacks_add_active_update_constraint (862.639417ms)
16/u expand_program_updates_table (883.807958ms)
17/u updates_remove_sha256 (881.622699ms)
18/u create_update_logs_table (872.431258ms)
19/u create_beta_access_table (851.40958ms)
20/u create_resources_table (843.330875ms)
21/u add_update_finalized_column (618.627729ms)
22/u create_tags_table (599.286039ms)
23/u bump_column_length (678.391897ms)
24/u create_invite_codes_table (680.397908ms)
25/u create_program_permissions_table (642.477024ms)
26/u create_subscriptions_table (673.649668ms)
27/u add_index_on_user_email (655.793389ms)
28/u add_collaborator_invites_table (646.71799ms)
29/u create_readonly_user (632.574332ms)
30/u add_programs_soft_delete (688.701222ms)
31/u index_orgs_github_login (692.821448ms)
32/u change_char_encoding (1.284219927s)
33/u add_email_to_collaborator_invites (1.290169183s)
34/u create_tokens_table (1.215560583s)
35/u expand_events_table (1.224581138s)
36/u add_github_installations_table (1.22598804s)
37/u add_commit_listener_tables (1.210602179s)
38/u add_github_pull_requests_table (1.208965786s)
39/u expand_orgs_table (1.221906859s)
40/u create_userkind_tables (1.250939965s)
41/u create_orgkind_tables (1.21707426s)
42/u backport_user_data (1.19310264s)
43/u backport_organization_data (579.702544ms)
44/u remove_subscriptons_table (588.63257ms)
45/u create_teams_table (643.401271ms)
46/u backport_org_settings (617.738143ms)
47/u create_pulumi_org_users (642.017529ms)
48/u backport_new_org_setting (588.958745ms)
49/u denormalize_resource_count (604.43468ms)
50/u add_saml_users_and_orgs (606.326777ms)
51/u create_billing_tables (594.227647ms)
52/u add_owner_to_githuborgs (582.192793ms)
53/u add_stack_count_to_orgs (612.416169ms)
54/u expand_github_app_tables (635.137337ms)
55/u expand_github_app_tables2 (647.344969ms)
56/u drop_cloud_config_table (579.43708ms)
57/u remove_cloud_fks (634.283808ms)
58/u migrate_legacy_access_tokens (590.938858ms)
59/u drop_unused_indexes (611.300281ms)
60/u add_gitlab_users_table (594.250918ms)
61/u add_unique_constraint_github_login_users (580.28956ms)
62/u add_gitlab_orgs_table (580.114941ms)
63/u create_engine_events_table (565.798616ms)
64/u recreate_engine_events_table (559.593731ms)
65/u create_webhooks_table (563.711754ms)
66/u create_webhook_delivery_tables (566.600661ms)
67/u add_is_hashed_column_to_access_tokens (590.349173ms)
68/u tighten_program_constraint (571.63076ms)
69/u drop_access_tokens_column (572.642482ms)
70/u drop_repo_name_from_programs (600.281089ms)
71/u hash_access_tokens_in_database (602.880462ms)
72/u create_saml_logins (602.984041ms)
73/u drop_is_hashed_column (612.306516ms)
74/u drop_unused_schema_objects (635.904461ms)
75/u create_bitbucket_users_table (631.733991ms)
76/u add_additional_program_index (618.698617ms)
77/u create_bitbucket_orgs_table (584.296924ms)
78/u drop_clouds_table (612.280856ms)
79/u expand_webhook_tables (666.917974ms)
80/u expand_subscriptions_table (723.420746ms)
81/u create_emailverifications_table (696.667637ms)
82/u add_unique_constraint_users_email (745.855498ms)
83/u create_org_members_table (746.126773ms)
84/u add_password_pulumiusers (768.745979ms)
85/u add_passwordresets_table (748.968924ms)
86/u expand_subscriptions_table (761.852155ms)
87/u backport_org_members (748.510922ms)
88/u backport_stack_admin_perm (734.764468ms)
89/u create_saml_identities_table (704.363106ms)
90/u add_saml_org_admin (648.860596ms)
91/u add_program_aliases_table (612.490544ms)
92/u update_organizations_github_login_unique (631.428469ms)
93/u create_programupdatesmetadatacs_table (580.980546ms)
94/u backport_programupdatemetadata (591.037925ms)
95/u expand_saml_identities_table (619.287339ms)
96/u expand_githubappinstallations_table (626.45176ms)
97/u expand_samlorganizations_table (623.792049ms)
98/u create_policypacks_table (650.762158ms)
99/u create_appliedpolicypacks_table (664.691451ms)
100/u expand_policypacks_table (666.030174ms)
101/u create_user_analytics_table (671.22087ms)
102/u create_program_update_policy_packs_table (667.455843ms)
103/u recreate_program_update_policy_packs_table (653.839877ms)
104/u expand_pulumi_organizations_table (669.462364ms)
105/u create_policy_groups_table (721.087019ms)
106/u backport_up_policy_groups (657.026497ms)
107/u remove_policy_group_programs_uniquness_constraint (688.614905ms)
108/u update_githubappinstallations_table (688.474375ms)
109/u create_program_updates_index (678.54617ms)
110/u drop_programupdatesmetadata_table (668.109015ms)
111/u create_program_reference_table (658.581084ms)
112/u add_settings_to_subscriptions (647.447183ms)
113/u add_support_plan_to_subscriptions (660.898647ms)
114/u backport_project_names (666.161965ms)
115/u create_audit_logs_table (653.625852ms)
116/u create_email_login_attempts_table (589.61017ms)
117/u add_locked_column_users (607.45942ms)
118/u update_subscriptions_table (578.095932ms)
119/u add_program_count_column_policygroups (578.782504ms)
120/u backport_program_count_for_policygroupprograms (559.538475ms)
121/u add_version_tag_column_policypacks (603.022868ms)
122/u create_policy_pack_configs (600.856457ms)
123/u add_config_columns_for_policy (655.505485ms)
124/u add_time_columns_to_policygrouppolicypacks (653.668802ms)
125/u create_background_jobs_table (646.273143ms)
126/u add_organizations_locked_column (657.616884ms)
127/u add_gitlabintegrations_table (661.622553ms)
128/u add_gitlabmergerequests_table (652.928276ms)
129/u add_programnotifications_table (640.011632ms)
130/u add_auditlog_orgsetting (608.639767ms)
131/u add_webhook_orgsetting (601.67181ms)
132/u create_rum_table (562.754458ms)
133/u add_computerum_backgroundjob (544.088567ms)
134/u update_samlidentities_table (480.267211ms)
135/u add_integration_assistant_orgsetting (449.689685ms)
136/u add_orgmemberinvites_table (446.458373ms)
137/u add_orgmemberrequests_table (435.335057ms)
138/u update_orgmemberinvites_table (440.899766ms)
139/u create_scimteams_table (456.459625ms)
140/u update_orgmemberinvites_table (464.017582ms)
141/u add_user_console_settings_table (488.073199ms)
142/u update_subscriptions_table (539.504422ms)
143/u backport_programupdates_resourcecount (555.675996ms)
144/u create_githubusers_login_index (579.83976ms)
145/u add_teammembers_role (627.448258ms)
146/u add_key_version_column_stacks (659.259585ms)
Database migrations completed!
~/go/src/github.com/pulumi/pulumi-service
```

After the first migration in the same terminal session with `SKIP_CREATE_DB_USER` still set, re-running the migrations will not run the `... force 1` command anymore.
```
pulumi-service on  praneetloke/7080-bump-pulumi-ee [$] via 🐹 v1.16.4 on ☁️  us-west-2 took 33s 
❯ MYSQL_ROOT_PASSWORD=test ./scripts/test-db-local.sh
Error response from daemon: network with name pulumi-ee already exists
Starting a new local MySQL container
~/go/src/github.com/pulumi/pulumi-service/pulumi-ee ~/go/src/github.com/pulumi/pulumi-service
pulumi-ee network exists already
MySQL container ID: ddb37ed7ee2b
    to kill: docker kill ddb37ed7ee2b
Waiting for MySQL to come alive ...
mysqld is alive
MySQL is running!
Running migrations
no change
Database migrations completed!
~/go/src/github.com/pulumi/pulumi-service
```