### PR TITLE
Bump timeout in run-self-hosted

### DIFF
--- a/.github/workflows/test-with-minio.yml
+++ b/.github/workflows/test-with-minio.yml
@@ -101,7 +101,7 @@ jobs:
           docker network connect pulumi-ee minio
 
       - uses: ./.github/actions/run-self-hosted
-        timeout-minutes: 2
+        timeout-minutes: 5
         with:
           compose-args: '-f ./all-in-one/docker-compose.yml -f ./all-in-one/docker-compose.edge.yml'
 


### PR DESCRIPTION
We are seeing a repeatable failure in the `minio-test` in this repo. This PR bumps a timeout from 2 to 5 minutes, which hopefully(?) will address the problem. But I wouldn't be surprised if the actual root cause was something else.

We are seeing a consistent failure in the `minio-test` during the "Run /./.github/actions/run-self-hosted" step. It starts running Docker Compose, and after two minutes times out.
<img width="723" alt="image" src="https://user-images.githubusercontent.com/4029847/139315595-a39ae463-1077-4c92-ba79-e722a2840e57.png">

https://github.com/pulumi/pulumi-ee/actions/runs/1395748276

We fortunately upload the service log file (which is awesome! ⭐ ⭐ ⭐ ) But it isn't really all that helpful, since it looks like the failure was when Docker was just starting to download a necessary container:

This is the contents of the `service-log` / `env.SERVICE_LOG` artifact for a recent test failure:

```
PULUMI_DATA_PATH was not set. Defaulting to 
Configuring new key for local object store encryption
pulumi-ee network exists already
Creating network "all-in-one_pulumi-services" with the default driver
Pulling db (mysql:5.6)...
5.6: Pulling from library/mysql
```

Maybe we just need to give Docker a little more time to pull down the `library/mysql` container? Let's find out...

Things I don't know:

- Why did this start failing yesterday? Maybe the `library/mysql` container changed, like it got much larger? Or GitHub Actions somehow has a contention issue? No idea.
- Where is `library/mysql`?  From `docker-compose.yml` we are using `image: "mysql:5.6"`. I don't know what pulling from `library/mysql` is referring to... I guess it is "[this thing](https://hub.docker.com/layers/mysql/library/mysql/5.6/images/sha256-6ba9428c3fbac40577e86367043c044f1edad9738629300ba0602d05bd1b12d1?context=explore)" on DockerHub?  So is it really just taking 2+ minutes to download?