### PR TITLE
Remove dependency on cloning the golang-migrate fork

### DIFF
--- a/scripts/migrate-db.sh
+++ b/scripts/migrate-db.sh
@@ -18,30 +18,8 @@ echo "Running migrations"
 # When this script is run inside the `pulumi/migrations` container,
 # this tool is pre-installed as part of creating the container image.
 which migratecli >/dev/null || {
-    echo "Building 'migratecli' from source."
-    CLONE_DIR="${GOPATH}/src/github.com/pulumi/golang-migrate"
-    git clone git@github.com:pulumi/golang-migrate.git "${CLONE_DIR}"
-    pushd "${CLONE_DIR}"
-    # https://github.com/golang-migrate/migrate/blob/master/CONTRIBUTING.md
-    INSTALL_DEST=${GOBIN:-$(go env GOPATH)/bin}
-
-    # If GOOS (read Go OS) is not set, then try and determine if this is a linux-like environment.
-    if [ -z "${GOOS:-}" ]; then
-        case $(uname) in
-            "Linux") GOOS="linux";;
-            "Darwin") GOOS="darwin";;
-            *)
-                echo "Unknown OS"
-                exit 1
-                ;;
-        esac
-    fi
-
-    GOOS="${GOOS}" DATABASE=mysql SOURCE=file CLI_BUILD_OUTPUT=${INSTALL_DEST}/migratecli make build-cli
-    popd
-
-    # Ensure the version we built is on the PATH for the rest of this script
-    export PATH="${INSTALL_DEST}:${PATH}"
+    echo "migratecli not found."
+    exit 1
 }
 
 DB_USER=pulumi_service


### PR DESCRIPTION
As outlined in my [comment](https://github.com/pulumi/pulumi-service/issues/7934#issuecomment-1026103549) this PR removes the need to clone the `golang-migrate` fork in the script and instead relies only on the migrations container image.

I don't think there is a practical reason right now to support other ways to run the migration scripts. If such a need arises, we should work with the customer to figure out what's the best way to deliver the migration scripts to them.

* [ ] Once this is merged, we should make a new release tag in this repo and then bump the required version in my draft PR in the service repo as well.