### PR TITLE
scripts: Allow docker image to be customized along with port exposed

### DIFF
--- a/scripts/init-db-container.sh
+++ b/scripts/init-db-container.sh
@@ -15,6 +15,10 @@ if [ -z "${MYSQL_ROOT_USERNAME:-}" ]; then
     MYSQL_ROOT_USERNAME=root
 fi
 
+if [ -z "${MYSQL_PORT:-}" ]; then
+    MYSQL_PORT=3306
+fi
+
 # If PULUMI_DATABASE_PING_ENDPOINT is not defined, then the "default" ping endpoint value
 # is determined using the RUN_MIGRATIONS_EXTERNALLY var.
 if [ -z "${PULUMI_DATABASE_PING_ENDPOINT:-}" ]; then
@@ -29,7 +33,7 @@ if [ -z "${PULUMI_DATABASE_PING_ENDPOINT:-}" ]; then
     fi
 fi
 
-while ! mysqladmin ping -h "${PULUMI_DATABASE_PING_ENDPOINT}" --user="${MYSQL_ROOT_USERNAME}" --password="${MYSQL_ROOT_PASSWORD}" --silent; do sleep 1; done
+while ! mysqladmin ping -h "${PULUMI_DATABASE_PING_ENDPOINT}" -P "${MYSQL_PORT}" --user="${MYSQL_ROOT_USERNAME}" --password="${MYSQL_ROOT_PASSWORD}" --silent; do sleep 1; done
 
 echo "MySQL is running!"
 

--- a/scripts/run-db-container.sh
+++ b/scripts/run-db-container.sh
@@ -6,6 +6,16 @@
 
 set -e
 
+# The docker image used for the database.
+if [ -z "${DEFAULT_DB_IMAGE:-}" ]; then
+  DEFAULT_DB_IMAGE=mysql:5.6
+fi
+
+# The port which the database is exposed.
+if [ -z "${MYSQL_PORT:-}" ]; then
+  MYSQL_PORT=3306
+fi
+
 # The volume mounted can be any stable/persistent file system.
 DEFAULT_DATA_PATH_BASE="${HOME}"
 DEFAULT_MYSQL_DATA_PATH="${DEFAULT_DATA_PATH_BASE}/pulumi-standalone-db/data"
@@ -39,12 +49,12 @@ MYSQL_CONT=$(docker ps --filter "name=pulumi-db" --format "{{.ID}}")
 if [ -z "${MYSQL_CONT:-}" ]; then
     # Boot up a MySQL 5.6 database.
     MYSQL_CONT=$(docker run \
-        --name pulumi-db -p 3306:3306 --rm -d \
+        --name pulumi-db -p ${MYSQL_PORT}:3306 --rm -d \
         --network pulumi-ee \
         -e MYSQL_ROOT_PASSWORD="${MYSQL_ROOT_PASSWORD}" \
         -e MYSQL_DATABASE=pulumi \
         -v "${MYSQL_DATA_PATH}":/var/lib/mysql \
-        mysql:5.6)
+       ${DEFAULT_DB_IMAGE})
 fi
 
 echo "MySQL container ID: $MYSQL_CONT"


### PR DESCRIPTION
Adds two env vars which allow for customizing the docker image as well
as allowing the port which is exposed to the docker host machine to be
customized.

Signed-off-by: Steve Sloka <steve@pulumi.com>