### PR TITLE
Change aws log groups to use name prefix instead

### DIFF
--- a/ecs-hosted/go/application/log/awsLogs.go
+++ b/ecs-hosted/go/application/log/awsLogs.go
@@ -8,7 +8,7 @@ import (
 
 func NewAwsLogs(ctx *pulumi.Context, name string, args *AwsArgs, opts ...pulumi.ResourceOption) (*AwsLogs, error) {
 	lg, err := cloudwatch.NewLogGroup(ctx, fmt.Sprintf("awslogs-%s", name), &cloudwatch.LogGroupArgs{
-		Name:            pulumi.String(fmt.Sprintf("cloudwatch-%s-logs", name)),
+		NamePrefix:      pulumi.String(fmt.Sprintf("cloudwatch-%s-logs", name)),
 		RetentionInDays: pulumi.Int(args.RetentionDays),
 	}, opts...)
 

--- a/ecs-hosted/go/application/service/migrationsService.go
+++ b/ecs-hosted/go/application/service/migrationsService.go
@@ -188,7 +188,7 @@ func NewMigrationsService(ctx *pulumi.Context, name string, args *MigrationsCont
 
 func newContainerDefinitions(ctx *pulumi.Context, name string, args *MigrationsContainerServiceArgs, image string, options ...pulumi.ResourceOption) (pulumi.StringOutput, error) {
 	logGroup, err := cloudwatch.NewLogGroup(ctx, fmt.Sprintf("%s-log-group", name), &cloudwatch.LogGroupArgs{
-		Name:            pulumi.String("pulumi-migration-logs"),
+		NamePrefix:      pulumi.String(fmt.Sprintf("%s-pulumi-migration-logs", name)),
 		RetentionInDays: pulumi.Int(1),
 	}, options...)
 


### PR DESCRIPTION
Instead of the `name` property user the `namePrefix` of the AWS Log Group to avoid potential naming collisions.