### PR TITLE
Update console2 hard-coded references

### DIFF
--- a/quickstart-docker-compose/all-in-one/docker-compose.override.yml
+++ b/quickstart-docker-compose/all-in-one/docker-compose.override.yml
@@ -27,7 +27,7 @@ services:
       - 3000:3000
     image: "pulumi/console:scratch"
     build:
-      context: ../../../cmd/console2
+      context: ../../../cmd/console
       args:
         - SKIP_PULUMI_CONSOLE_DOCKER_BUILD
 

--- a/quickstart-docker-compose/docker-compose.override.yml
+++ b/quickstart-docker-compose/docker-compose.override.yml
@@ -38,7 +38,7 @@ services:
       - 3443:3443
     image: "pulumi/console:scratch"
     build:
-      context: ../../cmd/console2
+      context: ../../cmd/console
       args:
         - SKIP_PULUMI_CONSOLE_DOCKER_BUILD
     environment:


### PR DESCRIPTION
This PR updates the references to `console2` to `console`, to accomodate work the service team is doing on an update UI.  These changes will allow our end-to-end integration tests to be run against the correct set of code.

This PR needs to be released in coordination with https://github.com/pulumi/pulumi-service/pull/9309 - if one is merged without the other, the pulumi-service e2e tests will fail.
