### PR TITLE
Add SAML cert env vars to the docker-compose.yml

### DIFF
--- a/quickstart-docker-compose/docker-compose.yml
+++ b/quickstart-docker-compose/docker-compose.yml
@@ -45,6 +45,11 @@ services:
       # Policy pack object storage (configure one)
       PULUMI_POLICY_PACK_LOCAL_HTTP_OBJECTS:
       PULUMI_POLICY_PACK_BLOB_STORAGE_ENDPOINT:
+
+      # SAML SSO Settings
+      SAML_CERTIFICATE_PUBLIC_KEY:
+      SAML_CERTIFICATE_PRIVATE_KEY:
+
       # AWS env vars
       AWS_REGION:
       AWS_PROFILE:


### PR DESCRIPTION
Since the service team uses the quickstart-docker-compose setup for e2e tests, if we want to have tests for saml orgs, we need to set the saml cert env vars in the container.