### PR TITLE
Fix call of ec2.getPrefixListOutput

### DIFF
--- a/ecs-hosted/ts/infrastructure/index.ts
+++ b/ecs-hosted/ts/infrastructure/index.ts
@@ -36,7 +36,7 @@ const s3Endpoint = new ec2.VpcEndpoint(`${config.commonName}-s3-endpoint`, {
 
 // retrieve the prefix id and export for downstream SGs to use
 const s3PrivatePrefixList = ec2.getPrefixListOutput({
-    name: s3Endpoint.prefixListId
+    prefixListId: s3Endpoint.prefixListId
 });
 
 new ec2.VpcEndpoint(`${config.commonName}-ecr-dkr-endpoint`, {


### PR DESCRIPTION
As the `prefixListId` is passed as criteria for selection the argument used should be `prefixListId` as well.

Using the wrong key to search the prefix list will result in the error: `no matching prefix list found; the prefix list ID or name may be invalid or not exist in the current region`