### PR TITLE
Update integ tests to MySQL 8

### DIFF
--- a/local-docker/README.md
+++ b/local-docker/README.md
@@ -22,7 +22,7 @@ The following are requirements of this deployment option:
 - Virtual machine or physical server with Docker Engine installed
     - At least 2 CPU cores w/ 8 GB memory
     - At least 20GB SSD storage space
-- MySQL 5.7 database
+- MySQL 8.0 database
     - At least 20GB SSD storage space
     - A databaser user that has the following grants:
         - `GRANT ALL PRIVILEGES ON 'pulumi'.* TO 'pulumi'@'%'`

--- a/quickstart-docker-compose/all-in-one/docker-compose.yml
+++ b/quickstart-docker-compose/all-in-one/docker-compose.yml
@@ -119,7 +119,7 @@ services:
     restart: unless-stopped
   
   db:
-    image: "mysql:5.7"
+    image: "mysql:8.0"
     environment:
       MYSQL_DATABASE: "pulumi"
       # This is set to true because we never expose the db service outside the local network.

--- a/quickstart-docker-compose/scripts/run-db-container.sh
+++ b/quickstart-docker-compose/scripts/run-db-container.sh
@@ -8,7 +8,7 @@ set -e
 
 # The docker image used for the database.
 if [ -z "${DEFAULT_DB_IMAGE:-}" ]; then
-  DEFAULT_DB_IMAGE=mysql:5.7
+  DEFAULT_DB_IMAGE=mysql:8.0
 fi
 
 # The port which the database is exposed.
@@ -47,7 +47,7 @@ fi
 MYSQL_CONT=$(docker ps --filter "name=pulumi-db" --format "{{.ID}}")
 
 if [ -z "${MYSQL_CONT:-}" ]; then
-    # Boot up a MySQL 5.7 database.
+    # Boot up a MySQL 8.0 database.
     MYSQL_CONT=$(docker run \
         --name pulumi-db -p ${MYSQL_PORT}:3306 --rm -d \
         --network pulumi-self-hosted-installers \


### PR DESCRIPTION
Upgrade quickstart-docker-compose mysql version from 5.7 to 8.0.

## Testing

Successfully executed locally with `MYSQL_PORT=3308 PULUMI_DATABASE_ENDPOINT=localhost:3308 ./scripts/local-mysql.sh`

## Related Issues

Fixes https://github.com/pulumi/pulumi-service/issues/11307