### PR TITLE
Update AKS installer to add allow list

### DIFF
--- a/aks-hosted/03-application/config.ts
+++ b/aks-hosted/03-application/config.ts
@@ -64,4 +64,5 @@ export const config = {
     recaptchaSecretKey: stackConfig.getSecret("recaptchaSecretKey") ?? defaultRecaptchaSecretKey,
     recaptchaSiteKey: stackConfig.get("recaptchaSiteKey") ?? defaultRecaptchaSiteKey,
     samlEnabled: stackConfig.get("samlEnabled") || "false",
+    ingressAllowList: stackConfig.get("ingressAllowList") || "",
 };

--- a/aks-hosted/README.md
+++ b/aks-hosted/README.md
@@ -91,6 +91,7 @@ Note if not set, "forgot password" and email invites will not work but sign ups 
 1. `pulumi config set smtpFromAddress {smtp from address}` (email address that the outgoing emails come from)
 1. `pulumi config set recaptchaSiteKey {recaptchaSiteKey}` (this must be a v2 type recaptcha)
 1. `pulumi config set recaptchaSecretKey {recaptchaSecretKey} --secret`
+1. `pulumi config set ingressAllowList {cidr range list}` (allow list of IPv4 CIDR ranges to allow access to the self-hosted Pulumi Cloud. Not setting this will allow the set up to be open to the internet)
 1. `pulumi up`
 
 ### Configure DNS

--- a/aks-hosted/README.md
+++ b/aks-hosted/README.md
@@ -91,7 +91,7 @@ Note if not set, "forgot password" and email invites will not work but sign ups 
 1. `pulumi config set smtpFromAddress {smtp from address}` (email address that the outgoing emails come from)
 1. `pulumi config set recaptchaSiteKey {recaptchaSiteKey}` (this must be a v2 type recaptcha)
 1. `pulumi config set recaptchaSecretKey {recaptchaSecretKey} --secret`
-1. `pulumi config set ingressAllowList {cidr range list}` (allow list of IPv4 CIDR ranges to allow access to the self-hosted Pulumi Cloud. Not setting this will allow the set up to be open to the internet)
+1. `pulumi config set ingressAllowList {cidr range list}` (allow list of IPv4 CIDR ranges to allow access to the self-hosted Pulumi Cloud. Not setting this will allow the set up to be open to the internet). [example](https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#whitelist-source-range)
 1. `pulumi up`
 
 ### Configure DNS

--- a/aks-hosted/README.md
+++ b/aks-hosted/README.md
@@ -91,7 +91,7 @@ Note if not set, "forgot password" and email invites will not work but sign ups 
 1. `pulumi config set smtpFromAddress {smtp from address}` (email address that the outgoing emails come from)
 1. `pulumi config set recaptchaSiteKey {recaptchaSiteKey}` (this must be a v2 type recaptcha)
 1. `pulumi config set recaptchaSecretKey {recaptchaSecretKey} --secret`
-1. `pulumi config set ingressAllowList {cidr range list}` (allow list of IPv4 CIDR ranges to allow access to the self-hosted Pulumi Cloud. Not setting this will allow the set up to be open to the internet). [example](https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#whitelist-source-range)
+1. `pulumi config set ingressAllowList {cidr range list}` (allow list of IPv4 CIDR ranges to allow access to the self-hosted Pulumi Cloud. Not setting this will allow the set up to be open to the internet). Proper formatting can be seen [here](https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#whitelist-source-range)
 1. `pulumi up`
 
 ### Configure DNS


### PR DESCRIPTION
Fixes: #107 

If set, the standard nginx 403 page will be displayed if you're not on one of those IP addresses:

<img width="601" alt="image" src="https://github.com/pulumi/pulumi-self-hosted-installers/assets/109047/d746d96e-1986-4a1f-b495-48426717cfdc">
