### PR TITLE
Allow user to user a pre-existing vnet

### DIFF
--- a/aks-hosted/01-infrastructure/config.ts
+++ b/aks-hosted/01-infrastructure/config.ts
@@ -1,15 +1,26 @@
 import * as pulumi from "@pulumi/pulumi";
 
 const stackConfig = new pulumi.Config();
-
 const projectName = pulumi.getProject();
 const stackName = pulumi.getStack();
 
 const commonName = "pulumiselfhosted" || stackConfig.get("commonName");
 const resourceNamePrefix = `${commonName}-${stackName}`;
 const disableAutoNaming = stackConfig.getBoolean("disableAutoNaming");
-const networkCidr = stackConfig.require("networkCidr");
 const subnetCidr = stackConfig.require("subnetCidr");
+const networkCidr = stackConfig.get("networkCidr");
+
+// if a user does elect to BYO vnet, they will be required to also supply the resource group name that houses the vnet
+const vnetId = stackConfig.get("virtualNetworkId");
+
+if (!networkCidr && !vnetId) {
+  throw new Error("Either networkCidr or virtualNetworkId must be present");
+}
+
+let vnetResourceGroup = "";
+if (vnetId) {
+  vnetResourceGroup = stackConfig.require("virtualNetworkResourceGroup");
+}
 
 export const config = {
   projectName,
@@ -18,7 +29,8 @@ export const config = {
   disableAutoNaming,
   networkCidr,
   subnetCidr,
-
+  vnetId,
+  vnetResourceGroup,
   baseTags: {
     project: projectName,
     stack: stackName,

--- a/aks-hosted/01-infrastructure/database.ts
+++ b/aks-hosted/01-infrastructure/database.ts
@@ -60,7 +60,7 @@ export class Database extends ComponentResource {
         });
 
         // https://docs.microsoft.com/en-us/azure/mysql/howto-troubleshoot-common-errors#error-1419-you-do-not-have-the-super-privilege-and-binary-logging-is-enabled-you-might-want-to-use-the-less-safe-log_bin_trust_function_creators-variable
-        const configuration = new dbformysql.Configuration(`${name}-config`, {
+        new dbformysql.Configuration(`${name}-config`, {
             resourceGroupName: args.resourceGroupName,
             serverName: server.name,
             source: "user-override",
@@ -97,4 +97,5 @@ export class Database extends ComponentResource {
             DatabaseServerName: this.DatabaseServerName,
         });
     }
+
 }

--- a/aks-hosted/01-infrastructure/index.ts
+++ b/aks-hosted/01-infrastructure/index.ts
@@ -5,58 +5,71 @@ import * as storage from "./storage";
 import * as db from "./database";
 import * as key from "./keyStorage";
 import { config } from "./config";
+import { output } from "@pulumi/pulumi";
 
-const resourceGroup = new resources.ResourceGroup(`${config.resourceNamePrefix}-rg`, {
-    resourceGroupName: config.disableAutoNaming ? `${config.resourceNamePrefix}-rg` : undefined,
-    tags: config.baseTags,
-}, { protect: true });
+export = async () => {
+    // although this RG may not house the vnet, it will house all the remaining resources we create
+    const resourceGroup = new resources.ResourceGroup(`${config.resourceNamePrefix}-rg`, {
+        resourceGroupName: config.disableAutoNaming ? `${config.resourceNamePrefix}-rg` : undefined,
+        tags: config.baseTags,
+    }, { protect: true });
+    
+    const adApplication = new ad.ActiveDirectoryApplication(`${config.resourceNamePrefix}`);
+    
+    // this will allow users to bring their own (BYO) virtual network, although we will still create a subnet
+    const vnetResourceGroupName = config.vnetResourceGroup && config.vnetResourceGroup != "" ? 
+        output(config.vnetResourceGroup) : 
+        resourceGroup.name;
 
-const adApplication = new ad.ActiveDirectoryApplication(`${config.resourceNamePrefix}`);
+    const network = new networking.Network(`${config.resourceNamePrefix}`, {
+        resourceGroupName: vnetResourceGroupName,
+        networkCidr: config.networkCidr,
+        subnetCidr: config.subnetCidr,
+        vnetId: config.vnetId,
+        tags: config.baseTags,
+    });
+    
+    const storageDetails = new storage.Storage(`${config.resourceNamePrefix}`, {
+        resourceGroupName: resourceGroup.name,
+        tags: config.baseTags,
+    });
+    
+    const database = new db.Database(`${config.resourceNamePrefix}`, {
+        resourceGroupName: resourceGroup.name,
+        subnetId: network.subnetId,
+        tags: config.baseTags,
+    });
+    
+    const kv = new key.KeyStorage(`${config.resourceNamePrefix}`, {
+        objectId: adApplication.PrincipalServerObjectId,
+        tenantId: adApplication.TenantId,
+        resourceGroupName: resourceGroup.name,
+        tags: config.baseTags,
+    });
 
-const network = new networking.Network(`${config.resourceNamePrefix}`, {
-    resourceGroupName: resourceGroup.name,
-    networkCidr: config.networkCidr,
-    subnetCidr: config.subnetCidr,
-    tags: config.baseTags,
-});
-
-const storageDetails = new storage.Storage(`${config.resourceNamePrefix}`, {
-    resourceGroupName: resourceGroup.name,
-    tags: config.baseTags,
-});
-
-const database = new db.Database(`${config.resourceNamePrefix}`, {
-    resourceGroupName: resourceGroup.name,
-    subnetId: network.subnetId,
-    tags: config.baseTags,
-});
-
-const kv = new key.KeyStorage(`${config.resourceNamePrefix}`, {
-    objectId: adApplication.PrincipalServerObjectId,
-    tenantId: adApplication.TenantId,
-    resourceGroupName: resourceGroup.name,
-    tags: config.baseTags,
-});
-
-export const resourceGroupName = resourceGroup.name;
-export const adGroupId = adApplication.GroupId;
-export const adApplicationId = adApplication.ApplicationId;
-export const adApplicationSecret = adApplication.ApplicationSecret
-export const tenantId = adApplication.TenantId;
-export const subscriptionId = adApplication.SubscriptionId;
-export const networkSubnetId = network.subnetId;
-export const storageAccountId = storageDetails.storageAccountId;
-export const storagePrimaryKey = storageDetails.storageAccountKey1;
-export const checkpointBlobId = storageDetails.checkpointBlobId;
-export const policyBlobId = storageDetails.policyBlobId;
-export const checkpointBlobName = storageDetails.checkpointBlobName;
-export const policyBlobName = storageDetails.policyBlobName;
-export const dbServerName = database.DatabaseServerName;
-export const dbLogin = database.DatabaseLogin;
-export const dbPassword = database.DatabasePassword;
-export const dbConnectionString = database.DatabaseConnectionString;
-export const storageAccountName = storageDetails.storageAccountName;
-export const keyvaultUri = kv.KeyVaultUri;
-export const keyvaultKeyName = kv.KeyName;
-export const keyvaultKeyVersion = kv.KeyVersion;
-export const stackName1 = config.stackName;
+    return {
+        resourceGroupName: resourceGroup.name,
+        adGroupId: adApplication.GroupId,
+        adApplicationId: adApplication.ApplicationId,
+        adApplicationSecret: adApplication.ApplicationSecret,
+        tenantId: adApplication.TenantId,
+        subscriptionId: adApplication.SubscriptionId,
+        networkSubnetId: network.subnetId,
+        storageAccountId: storageDetails.storageAccountId,
+        storagePrimaryKey: storageDetails.storageAccountKey1,
+        checkpointBlobId: storageDetails.checkpointBlobId,
+        policyBlobId: storageDetails.policyBlobId,
+        checkpointBlobName: storageDetails.checkpointBlobName,
+        policyBlobName: storageDetails.policyBlobName,
+        storageAccountName: storageDetails.storageAccountName,
+        dbServerName: database.DatabaseServerName,
+        dbLogin: database.DatabaseLogin,
+        dbPassword: database.DatabasePassword,
+        dbConnectionString: database.DatabaseConnectionString,
+        keyvaultUri: kv.KeyVaultUri,
+        keyvaultKeyName: kv.KeyName,
+        keyvaultKeyVersion: kv.KeyVersion,
+        stackName1: config.stackName,
+        baseTags: config.baseTags
+    };
+};

--- a/aks-hosted/01-infrastructure/network.ts
+++ b/aks-hosted/01-infrastructure/network.ts
@@ -1,11 +1,12 @@
 import * as pulumi from "@pulumi/pulumi";
 import { network } from "@pulumi/azure-native";
-import { Input, Output, ComponentResource, ComponentResourceOptions } from "@pulumi/pulumi";
+import { Input, Output, ComponentResource, log } from "@pulumi/pulumi";
 
 export interface NetworkArgs {
   resourceGroupName: Output<string>,
-  networkCidr: string,
   subnetCidr: string,
+  networkCidr?: string,
+  vnetId?: string,
   tags?: Input<{
     [key: string]: Input<string>;
   }>,
@@ -16,17 +17,28 @@ export class Network extends ComponentResource {
   constructor(name: string, args: NetworkArgs) {
     super("x:infrastructure:networking", name);
 
-    const vnet = new network.VirtualNetwork(`${name}-vnet`, {
-      resourceGroupName: args.resourceGroupName,
-      addressSpace: {
-        addressPrefixes: [args.networkCidr],
-      },
-      tags: args.tags,
-    }, { parent: this, ignoreChanges: ["subnets", "etags"] }); // ignore changes due to https://github.com/pulumi/pulumi-azure-native/issues/611#issuecomment-721490800
+    if (!args.networkCidr && !args.vnetId) {
+      const err = "Network requires one of vnetId or networkCidr to be populated"
+      log.error(err);
+      throw new Error(err)
+    }
+
+    // allow users to provide their own vnet, if they elect
+    let vnet: network.VirtualNetwork;
+    if (args.vnetId) {
+      vnet = network.VirtualNetwork.get(`${name}-vnet`, args.vnetId!);
+    } else {
+      vnet = new network.VirtualNetwork(`${name}-vnet`, {
+        resourceGroupName: args.resourceGroupName,
+        addressSpace: {
+          addressPrefixes: [args.networkCidr!],
+        },
+        tags: args.tags,
+      }, { parent: this, ignoreChanges: ["subnets", "etags"] }); // ignore changes due to https://github.com/pulumi/pulumi-azure-native/issues/611#issuecomment-721490800
+    }
 
     const subnet = new network.Subnet(`${name}-snet`, {
       resourceGroupName: args.resourceGroupName,
-
       virtualNetworkName: vnet.name,
       addressPrefix: args.subnetCidr,
       serviceEndpoints: [{

--- a/aks-hosted/02-kubernetes/cluster.ts
+++ b/aks-hosted/02-kubernetes/cluster.ts
@@ -64,6 +64,9 @@ export class KubernetesCluster extends ComponentResource {
       },
       kubernetesVersion: "1.26.3",
       nodeResourceGroup: `${name}-aks-nodes-rg`,
+      networkProfile: {
+        networkPlugin: "azure",
+      },
       tags: args.tags,
       networkProfile: {
         networkPlugin: "azure"

--- a/aks-hosted/02-kubernetes/config.ts
+++ b/aks-hosted/02-kubernetes/config.ts
@@ -15,12 +15,10 @@ export const config = {
     projectName,
     stackName,
     resourceNamePrefix,
-
     baseTags: {
         project: projectName,
         stack: stackName,
     },
-    
     resourceGroupName: <Output<string>>infrastructureStack.requireOutput("resourceGroupName"),
     adGroupId: <Output<string>>infrastructureStack.requireOutput("adGroupId"),
     adApplicationId: <Output<string>>infrastructureStack.requireOutput("adApplicationId"),

--- a/aks-hosted/README.md
+++ b/aks-hosted/README.md
@@ -60,8 +60,11 @@ To deploy entire stack, run the following in your terminal:
 1. `pulumi stack init {stackName1}` - see note above about NO NUMBERS in stack name
 1. `pulumi config set azure-native:location {azure region}`
 1. `pulumi config set networkCidr 10.2.0.0/16` - this should be set to what you want your VNet cidr block to be
+**Note** if you elect to provide an existing Azure VirtualNetwork, instead of `networkCidr` you'll be required to provide the following:
+1. `pulumi config set virtualNetworkId /subscriptions/0282681f-7a9e-424b-80b2-96babd57a8a1/resourceGroups/someRG/providers/Microsoft.Network/virtualNetworks/some-vnet`
+1. `pulumi config set virtualNetworkResourceGroup someRG` (the resource groupname from the existing vnet)
 1. `pulumi config set subnetCidr 10.2.1.0/24` - this should be set to what you want your subnet cidr block to be
-1. `az login` (to avoid the following error: Could not create service principal: graphrbac.ServicePrincipalsClient#Create: Failure )
+1. `az login` (to avoid the following error: Could not create service principal: graphrbac.ServicePrincipalsClient#Create: Failure)
 1. `pulumi up`
 1. `cd ../02-kubernetes`
 1. `npm install`

--- a/aks-hosted/README.md
+++ b/aks-hosted/README.md
@@ -60,9 +60,7 @@ To deploy entire stack, run the following in your terminal:
 1. `pulumi stack init {stackName1}` - see note above about NO NUMBERS in stack name
 1. `pulumi config set azure-native:location {azure region}`
 1. `pulumi config set networkCidr 10.2.0.0/16` - this should be set to what you want your VNet cidr block to be  
-
-**Note** if you elect to provide an existing Azure VirtualNetwork, instead of `networkCidr` you'll be required to provide the following:
-1. `pulumi config set virtualNetworkId /subscriptions/0282681f-7a9e-424b-80b2-96babd57a8a1/resourceGroups/someRG/providers/Microsoft.Network/virtualNetworks/some-vnet`
+1. **Note** if you elect to provide an existing Azure VirtualNetwork, instead of `networkCidr` you'll be required to provide the following:`pulumi config set virtualNetworkId /subscriptions/0282681f-7a9e-424b-80b2-96babd57a8a1/resourceGroups/someRG/providers/Microsoft.Network/virtualNetworks/some-vnet`
 1. `pulumi config set virtualNetworkResourceGroup someRG` (the resource groupname from the existing vnet)
 1. `pulumi config set subnetCidr 10.2.1.0/24` - this should be set to what you want your subnet cidr block to be
 1. `az login` (to avoid the following error: Could not create service principal: graphrbac.ServicePrincipalsClient#Create: Failure)

--- a/aks-hosted/README.md
+++ b/aks-hosted/README.md
@@ -59,7 +59,8 @@ To deploy entire stack, run the following in your terminal:
 1. `npm install`
 1. `pulumi stack init {stackName1}` - see note above about NO NUMBERS in stack name
 1. `pulumi config set azure-native:location {azure region}`
-1. `pulumi config set networkCidr 10.2.0.0/16` - this should be set to what you want your VNet cidr block to be
+1. `pulumi config set networkCidr 10.2.0.0/16` - this should be set to what you want your VNet cidr block to be  
+
 **Note** if you elect to provide an existing Azure VirtualNetwork, instead of `networkCidr` you'll be required to provide the following:
 1. `pulumi config set virtualNetworkId /subscriptions/0282681f-7a9e-424b-80b2-96babd57a8a1/resourceGroups/someRG/providers/Microsoft.Network/virtualNetworks/some-vnet`
 1. `pulumi config set virtualNetworkResourceGroup someRG` (the resource groupname from the existing vnet)


### PR DESCRIPTION
This PR allows users to use a pre-existing VNET rather than have one created as part of the AKS installer.

The changes of consequence are:
- if user elects to bring their own vnet, lookup the vnet by the provided ID otherwise create a new one
- no long specify the AAD password as this is a deprecated property