### PR TITLE
add explicit public ip address rather than use aks allocated IP.

### DIFF
--- a/aks-hosted/02-kubernetes/index.ts
+++ b/aks-hosted/02-kubernetes/index.ts
@@ -21,8 +21,10 @@ const provider = new Provider("k8s-provider", {
 
 const ingress = new NginxIngress("pulumi-selfhosted", {
     provider,
+    publicIpAddress: cluster.PublicIp,
 }, { dependsOn: cluster });
 
+export const publicIp = cluster.PublicIp;
 export const ingressNamespace = ingress.IngressNamespace;
-export const ingressServiceIp = ingress.IngressServiceIp;
+//export const ingressServiceIp = ingress.IngressServiceIp;
 export const stackName2 = config.stackName;


### PR DESCRIPTION
This allows the IP address of the ingress to remain static, in the case that the cluster is replaced. This stops users from having to update DNS entries (a records) in the event the cluster needs to be replaced.