### PR TITLE
Utilize cert-manager to mange TLS certs in connection w/ Azure DNS

### DIFF
--- a/aks-hosted/01-infrastructure/config.ts
+++ b/aks-hosted/01-infrastructure/config.ts
@@ -11,14 +11,14 @@ const subnetCidr = stackConfig.require("subnetCidr");
 const networkCidr = stackConfig.get("networkCidr");
 
 // if a user does elect to BYO vnet, they will be required to also supply the resource group name that houses the vnet
-const vnetId = stackConfig.get("virtualNetworkId");
+const vnetName = stackConfig.get("virtualNetworkName");
 
-if (!networkCidr && !vnetId) {
+if (!networkCidr && !vnetName) {
   throw new Error("Either networkCidr or virtualNetworkId must be present");
 }
 
 let vnetResourceGroup = "";
-if (vnetId) {
+if (vnetName) {
   vnetResourceGroup = stackConfig.require("virtualNetworkResourceGroup");
 }
 
@@ -29,7 +29,7 @@ export const config = {
   disableAutoNaming,
   networkCidr,
   subnetCidr,
-  vnetId,
+  vnetName,
   vnetResourceGroup,
   baseTags: {
     project: projectName,

--- a/aks-hosted/01-infrastructure/index.ts
+++ b/aks-hosted/01-infrastructure/index.ts
@@ -25,7 +25,7 @@ export = async () => {
         resourceGroupName: vnetResourceGroupName,
         networkCidr: config.networkCidr,
         subnetCidr: config.subnetCidr,
-        vnetId: config.vnetId,
+        vnetName: config.vnetName,
         tags: config.baseTags,
     });
     

--- a/aks-hosted/01-infrastructure/network.ts
+++ b/aks-hosted/01-infrastructure/network.ts
@@ -3,13 +3,13 @@ import { network } from "@pulumi/azure-native";
 import { Input, Output, ComponentResource, log } from "@pulumi/pulumi";
 
 export interface NetworkArgs {
-  resourceGroupName: Output<string>,
-  subnetCidr: string,
-  networkCidr?: string,
-  vnetId?: string,
+  resourceGroupName: Output<string>;
+  subnetCidr: string;
+  networkCidr?: string;
+  vnetName?: string;
   tags?: Input<{
     [key: string]: Input<string>;
-  }>,
+  }>;
 };
 
 export class Network extends ComponentResource {
@@ -17,34 +17,40 @@ export class Network extends ComponentResource {
   constructor(name: string, args: NetworkArgs) {
     super("x:infrastructure:networking", name);
 
-    if (!args.networkCidr && !args.vnetId) {
+    if (!args.networkCidr && !args.vnetName) {
       const err = "Network requires one of vnetId or networkCidr to be populated"
       log.error(err);
       throw new Error(err)
     }
 
     // allow users to provide their own vnet, if they elect
-    let vnet: network.VirtualNetwork;
-    if (args.vnetId) {
-      vnet = network.VirtualNetwork.get(`${name}-vnet`, args.vnetId!);
+    let vnetName: Output<string>;
+    if (args.vnetName) {
+      const preExisting = network.getVirtualNetworkOutput({
+        resourceGroupName: args.resourceGroupName,
+        virtualNetworkName: args.vnetName,
+      });
+
+      vnetName = preExisting.name;
     } else {
-      vnet = new network.VirtualNetwork(`${name}-vnet`, {
+      const vnet = new network.VirtualNetwork(`${name}-vnet`, {
         resourceGroupName: args.resourceGroupName,
         addressSpace: {
           addressPrefixes: [args.networkCidr!],
         },
         tags: args.tags,
       }, { parent: this, ignoreChanges: ["subnets", "etags"] }); // ignore changes due to https://github.com/pulumi/pulumi-azure-native/issues/611#issuecomment-721490800
+      vnetName = vnet.name;
     }
 
     const subnet = new network.Subnet(`${name}-snet`, {
       resourceGroupName: args.resourceGroupName,
-      virtualNetworkName: vnet.name,
+      virtualNetworkName: vnetName,
       addressPrefix: args.subnetCidr,
       serviceEndpoints: [{
         service: "Microsoft.Sql"
       }],
-    }, { parent: vnet });
+    }, { parent: this });
 
     this.subnetId = subnet.id;
     this.registerOutputs({

--- a/aks-hosted/02-kubernetes/cert-manager.ts
+++ b/aks-hosted/02-kubernetes/cert-manager.ts
@@ -1,0 +1,49 @@
+import { ComponentResource, ComponentResourceOptions, Output } from "@pulumi/pulumi";
+import { core, helm, Provider } from "@pulumi/kubernetes";
+
+export interface CertManagerArgs {
+    provider: Provider;
+    certManagerNamespaceName: string;
+}
+
+export class CertManager extends ComponentResource {
+    public readonly CertManagerNamespace: Output<string>;
+    public readonly CertManagerName: Output<string>;
+
+    constructor(name: string, args: CertManagerArgs, opts?: ComponentResourceOptions) {
+        super("x:kubernetes:certManager", name, args, opts);
+
+        const certManagerNamespace = new core.v1.Namespace(`${name}-namespace`, {
+            metadata: {
+                name: args.certManagerNamespaceName,
+            },
+        }, { provider: args.provider, dependsOn: opts?.dependsOn, parent: this });
+
+        const certManager = new helm.v3.Release("cert-manager", {
+            chart: "cert-manager",
+            repositoryOpts: {
+                repo: "https://charts.jetstack.io"
+            },
+            namespace: certManagerNamespace.metadata.name,
+            version: "1.12.1",
+            values: {
+                installCRDs: true,
+                podLabels: {
+                    "azure.workload.identity/use": "true"
+                },
+                serviceAccount: {
+                    lables: {
+                        "azure.workload.identity/use": "true"
+                    }
+                }
+            }
+        }, { provider: args.provider, dependsOn: opts?.dependsOn, parent: this });
+
+        this.CertManagerNamespace = certManagerNamespace.metadata.name;
+        this.CertManagerName = certManager.status.name;
+        this.registerOutputs({
+            CertManagerNamespace: this.CertManagerNamespace,
+            CertManagerName: this.CertManagerName,
+        });
+    }
+}

--- a/aks-hosted/02-kubernetes/config.ts
+++ b/aks-hosted/02-kubernetes/config.ts
@@ -11,10 +11,23 @@ const stackName = getStack();
 const commonName = "pulumi-selfhosted" || stackConfig.get("commonName");
 const resourceNamePrefix = `${commonName}-${stackName}`;
 
+// if enabled, this boolean controls whether or not cert-manager will be deployed and managed identity created for workloads to assume
+// while this is the preferred way of managing certs, it is not required
+const enableAzureDnsCertManagement = stackConfig.getBoolean("enableAzureDnsCertManagement") || false;
+let azureDnsZoneName = undefined;
+let azureDnsZoneResourceGroup = undefined;
+if (enableAzureDnsCertManagement) {
+    azureDnsZoneName = stackConfig.require("azureDnsZoneName");
+    azureDnsZoneResourceGroup = stackConfig.require("azureDnsZoneResourceGroup");
+}
+
 export const config = {
     projectName,
     stackName,
     resourceNamePrefix,
+    enableAzureDnsCertManagement,
+    azureDnsZoneName,
+    azureDnsZoneResourceGroup,
     baseTags: {
         project: projectName,
         stack: stackName,

--- a/aks-hosted/02-kubernetes/helm-nginx-ingress.ts
+++ b/aks-hosted/02-kubernetes/helm-nginx-ingress.ts
@@ -15,7 +15,7 @@ export class NginxIngress extends ComponentResource {
             metadata: {
                 name: `${name}-ingress`,
             },
-        }, {provider: args.provider, dependsOn: opts?.dependsOn, parent: this});
+        }, { provider: args.provider, dependsOn: opts?.dependsOn, parent: this });
 
         const nginx = new helm.v3.Release(`ingress`, {
             chart: "ingress-nginx",
@@ -38,7 +38,7 @@ export class NginxIngress extends ComponentResource {
                         }
                     },
                     service: {
-                        "externalTrafficPolicy":"Local", // https://github.com/MicrosoftDocs/azure-docs/issues/92179#issuecomment-1169809165
+                        "externalTrafficPolicy": "Local", // https://github.com/MicrosoftDocs/azure-docs/issues/92179#issuecomment-1169809165
                         "loadBalancerIP": args.publicIpAddress,
                     },
                 },
@@ -48,7 +48,7 @@ export class NginxIngress extends ComponentResource {
                     }
                 }
             },
-        }, {provider: args.provider, dependsOn: opts?.dependsOn, parent: ingressNamespace})
+        }, { provider: args.provider, dependsOn: opts?.dependsOn, parent: ingressNamespace })
 
         this.IngressNamespace = ingressNamespace.metadata.name;
         this.registerOutputs({

--- a/aks-hosted/02-kubernetes/identity.ts
+++ b/aks-hosted/02-kubernetes/identity.ts
@@ -1,0 +1,61 @@
+import { ComponentResource, ComponentResourceOptions, Output, Input, interpolate } from "@pulumi/pulumi";
+import { authorization, managedidentity, network } from "@pulumi/azure-native";
+
+export interface IdentityArgs {
+    azureDnsZone: Output<string>;
+    azureDnsZoneResourceGroup: Output<string>;
+    certManagerName: Output<string>;
+    certManagerNamespaceName: Output<string>;
+    clusterOidcIssuerUrl: Output<string | undefined>;
+    nodeResourceGroupName: Output<string | undefined>;
+    tags?: Input<{
+        [key: string]: Input<string>;
+    }>,
+}
+
+export class Identity extends ComponentResource {
+    public readonly ClientId: Output<string>;
+    constructor(name: string, args: IdentityArgs, opts?: ComponentResourceOptions) {
+        super("x:kubernetes:identity", name, args, opts);
+
+        const resourceGroupName = assertValue(args.nodeResourceGroupName, "nodeResourceGroup");
+        const issuerUrl = assertValue(args.clusterOidcIssuerUrl, "oidcIssuerUrl");
+
+        const dnsZone = network.getZoneOutput({
+            zoneName: args.azureDnsZone,
+            resourceGroupName: args.azureDnsZoneResourceGroup
+        });
+
+        const user = new managedidentity.UserAssignedIdentity(`${name}-managed-id`, {
+            resourceGroupName: resourceGroupName,
+            tags: args.tags,
+        }, { parent: this });
+
+        new authorization.RoleAssignment(`${name}-role-assignment`, {
+            roleDefinitionId: "/providers/Microsoft.Authorization/roleDefinitions/befefa01-2a29-4197-83a8-272ff33ce314",
+            scope: dnsZone.id,
+            principalId: user.principalId,
+            principalType: "ServicePrincipal"
+        }, { parent: this });
+
+        new managedidentity.FederatedIdentityCredential(`${name}-federated-cred`, {
+            resourceName: user.name,
+            resourceGroupName: resourceGroupName,
+            issuer: issuerUrl,
+            subject: interpolate `system:serviceaccount:${args.certManagerNamespaceName}:${args.certManagerName}`,
+            audiences: ["api://AzureADTokenExchange"],
+        }, { parent: this });
+
+        this.ClientId = user.clientId;
+    }
+}
+
+const assertValue = (val: Output<string | undefined>, name: string) => {
+    return val.apply(v => {
+        if (!v) {
+            throw new Error(`${name} must not be undefined`);
+        }
+
+        return v!;
+    });
+}

--- a/aks-hosted/03-application/cert-manager.ts
+++ b/aks-hosted/03-application/cert-manager.ts
@@ -1,0 +1,96 @@
+import { ComponentResource, ComponentResourceOptions, Output, all } from "@pulumi/pulumi";
+import { Provider, apiextensions } from "@pulumi/kubernetes";
+
+export interface CertManagerArgs {
+    provider: Provider,
+    domains: string[],
+    certSecretName: string,
+    namespaceName: Output<string>;
+    subscriptionId: Output<string>;
+    resourceGroupName: string;
+    hostedZoneName: string;
+    managedClientId: string;
+    issuerEmail?: string;
+}
+
+export class CertManagerDeployment extends ComponentResource {
+    constructor(name: string, args: CertManagerArgs, opts?: ComponentResourceOptions) {
+        super("x:kubernetes:certManagerDeployment", name, args, opts);
+
+        const letsEncryptUrl = "https://acme-v02.api.letsencrypt.org/directory";
+        // FOR TESTING:
+        // const letsEncryptUrl = "https://acme-staging-v02.api.letsencrypt.org/directory";
+        const acmeSpec = args.issuerEmail ?
+            {
+                server: letsEncryptUrl,
+                email: args.issuerEmail,
+                privateKeySecretRef: {
+                    name: "acme-issuer"
+                },
+                solvers: [{
+                    dns01: {
+                        azureDNS: {
+                            resourceGroupName: args.resourceGroupName,
+                            subscriptionID: args.subscriptionId,
+                            hostedZoneName: args.hostedZoneName,
+                            environment: "AzurePublicCloud",
+                            managedIdentity: {
+                                clientID: args.managedClientId,
+                            },
+                        }
+                    }
+                }]
+            } :
+            {
+                server: letsEncryptUrl,
+                privateKeySecretRef: {
+                    name: "acme-issuer"
+                },
+                solvers: [{
+                    dns01: {
+                        azureDNS: {
+                            resourceGroupName: args.resourceGroupName,
+                            subscriptionID: args.subscriptionId,
+                            hostedZoneName: args.hostedZoneName,
+                            environment: "AzurePublicCloud",
+                            managedIdentity: {
+                                clientID: args.managedClientId,
+                            },
+                        }
+                    }
+                }]
+            };
+
+        const issuer = new apiextensions.CustomResource(`${name}-issuer`, {
+            apiVersion: "cert-manager.io/v1",
+            kind: "ClusterIssuer",
+            metadata: {
+                namespace: args.namespaceName
+            },
+            spec: {
+                acme: acmeSpec
+            }
+        }, { provider: args.provider, parent: this });
+
+        new apiextensions.CustomResource(`${name}-cert`, {
+            apiVersion: "cert-manager.io/v1",
+            kind: "Certificate",
+            metadata: {
+                namespace: args.namespaceName
+            },
+            spec: {
+                secretName: args.certSecretName,
+                dnsNames: args.domains,
+                issuerRef: {
+                    name: issuer.metadata.name,
+                    kind: "ClusterIssuer"
+                },
+                usages: [
+                    "digital signature",
+                    "key encipherment",
+                    "server auth"
+                ],
+            }
+        }, { provider: args.provider, parent: this });
+    }
+}

--- a/aks-hosted/03-application/config.ts
+++ b/aks-hosted/03-application/config.ts
@@ -1,68 +1,121 @@
-import { Config, StackReference, getStack, getProject } from "@pulumi/pulumi";
+import { Config, StackReference, getStack, getProject, StackReferenceOutputDetails, Output } from "@pulumi/pulumi";
 
-const stackConfig = new Config();
+export const getConfig = async () => {
+    const stackConfig = new Config();
 
-const commonName = "pulumi-selfhosted" || stackConfig.get("commonName");
-const projectName = getProject();
-const stackName = getStack();
+    const commonName = "pulumi-selfhosted" || stackConfig.get("commonName");
+    const projectName = getProject();
+    const stackName = getStack();
 
-const resourceNamePrefix = `${commonName}-${stackName}`;
+    const resourceNamePrefix = `${commonName}-${stackName}`;
 
-const imageTag = stackConfig.require("imageTag");
+    const imageTag = stackConfig.require("imageTag");
 
-const stackName1 = stackConfig.require("stackName1");
-const stackName2 = stackConfig.require("stackName2");
+    const stackName1 = stackConfig.require("stackName1");
+    const stackName2 = stackConfig.require("stackName2");
+    const certManagerEmail = stackConfig.get("certManagerEmail");
 
-const infrastructureStack = new StackReference(stackName1);
-const clusterStack = new StackReference(stackName2);
+    const infrastructureStack = new StackReference(stackName1);
+    const clusterStack = new StackReference(stackName2);
 
-const defaultRecaptchaSiteKey = "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"
-const defaultRecaptchaSecretKey = "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"
+    const defaultRecaptchaSiteKey = "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI";
+    const defaultRecaptchaSecretKey = "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe";
 
-export const config = {
-    projectName,
-    stackName,
-    resourceNamePrefix,
+    // the below enableAzureDnsCertManagement will cause the legacy certs and keys to be ignored as well ass
+    // a cluster issuer and cert created using letsencrypt w/ DNs01 validation via Azure DNS
+    const enableAzureDnsCertManagementValue = await clusterStack.getOutputDetails("enableAzureDnsCertManagement");
+    const enableAzureDnsCertManager = getValue<boolean>(enableAzureDnsCertManagementValue, false);
 
-    kubeconfig: clusterStack.requireOutput("kubeconfig"),
-    licenseKey: stackConfig.requireSecret("licenseKey"),
-    database: {
-        connectionString: infrastructureStack.requireOutput("dbConnectionString"),
-        login: infrastructureStack.requireOutput("dbLogin"),
-        password: infrastructureStack.requireOutput("dbPassword"),
-        serverName: infrastructureStack.requireOutput("dbServerName")
-    },
-    migrationImageName: `pulumi/migrations:${imageTag}`,
-    consoleImageName: `pulumi/console:${imageTag}`,
-    serviceImageName: `pulumi/service:${imageTag}`,
-    servicePort: 8080,
-    consolePort: 3000,
-    policyBlobId: infrastructureStack.requireOutput("policyBlobId"),
-    policyBlobName: infrastructureStack.requireOutput("policyBlobName"),
-    checkpointBlobId: infrastructureStack.requireOutput("checkpointBlobId"),
-    checkpointBlobName: infrastructureStack.requireOutput("checkpointBlobName"),
-    storageAccountId: infrastructureStack.requireOutput("storageAccountId"),
-    apiDomain: stackConfig.require("apiDomain"),
-    consoleDomain: stackConfig.require("consoleDomain"),
-    apiTlsKey: stackConfig.requireSecret("apiTlsKey"),
-    apiTlsCert: stackConfig.requireSecret("apiTlsCert"),
-    consoleTlsKey: stackConfig.requireSecret("consoleTlsKey"),
-    consoleTlsCert: stackConfig.requireSecret("consoleTlsCert"),
-    tenantId: infrastructureStack.requireOutput("tenantId"),
-    subscriptionId: infrastructureStack.requireOutput("subscriptionId"),
-    clientId: infrastructureStack.requireOutput("adApplicationId"),
-    clientSecret: infrastructureStack.requireOutput("adApplicationSecret"),
-    storageKey: infrastructureStack.requireOutput("storagePrimaryKey"),
-    storageAccountName: infrastructureStack.requireOutput("storageAccountName"),
-    keyvaultKeyName: infrastructureStack.requireOutput("keyvaultKeyName"),
-    keyvaultKeyVersion: infrastructureStack.requireOutput("keyvaultKeyVersion"),
-    keyvaultUri: infrastructureStack.requireOutput("keyvaultUri"),
-    smtpServer: stackConfig.get("smtpServer") || "",
-    smtpUsername: stackConfig.get("smtpUsername") || "",
-    smtpPassword: stackConfig.getSecret("smtpPassword") || "",
-    smtpFromAddress: stackConfig.get("smtpFromAddress") || "message@pulumi.com",
-    recaptchaSecretKey: stackConfig.getSecret("recaptchaSecretKey") ?? defaultRecaptchaSecretKey,
-    recaptchaSiteKey: stackConfig.get("recaptchaSiteKey") ?? defaultRecaptchaSiteKey,
-    samlEnabled: stackConfig.get("samlEnabled") || "false",
-    ingressAllowList: stackConfig.get("ingressAllowList") || "",
+    const azureDnsZoneValue = await clusterStack.getOutputDetails("azureDnsZone");
+    const azureDnsZone = getValue<string>(azureDnsZoneValue, "");
+
+    const azureDnsZoneResourceGroupValue = await clusterStack.getOutputDetails("azureDnsZoneResourceGroup");
+    const azureDnsZoneResourceGroup = getValue<string>(azureDnsZoneResourceGroupValue, "");
+
+    const certManagerNamespaceValue = await clusterStack.getOutputDetails("certManagerNamespace");
+    const certManagerNamespace = getValue<string>(certManagerNamespaceValue, "");
+
+    const managedClientIdValue = await clusterStack.getOutputDetails("managedClientId");
+    const managedClientId = getValue<string>(managedClientIdValue, "");
+
+    // with the addition of cert-manager, we will treat the certs and keys from config as legacy and not required.
+    let apiTlsCert: Output<string> | undefined;
+    let apiTlsKey: Output<string> | undefined;
+    let consoleTlsCert: Output<string> | undefined;
+    let consoleTlsKey: Output<string> | undefined;
+    if (!enableAzureDnsCertManager) {
+        apiTlsKey = stackConfig.requireSecret("apiTlsKey");
+        apiTlsCert = stackConfig.requireSecret("apiTlsCert");
+        consoleTlsKey = stackConfig.requireSecret("consoleTlsKey");
+        consoleTlsCert = stackConfig.requireSecret("consoleTlsCert");
+    }
+
+    return {
+        projectName,
+        stackName,
+        resourceNamePrefix,
+        kubeconfig: clusterStack.requireOutput("kubeconfig"),
+        licenseKey: stackConfig.requireSecret("licenseKey"),
+        database: {
+            connectionString: infrastructureStack.requireOutput("dbConnectionString"),
+            login: infrastructureStack.requireOutput("dbLogin"),
+            password: infrastructureStack.requireOutput("dbPassword"),
+            serverName: infrastructureStack.requireOutput("dbServerName")
+        },
+        migrationImageName: `pulumi/migrations:${imageTag}`,
+        consoleImageName: `pulumi/console:${imageTag}`,
+        serviceImageName: `pulumi/service:${imageTag}`,
+        servicePort: 8080,
+        consolePort: 3000,
+        policyBlobId: infrastructureStack.requireOutput("policyBlobId"),
+        policyBlobName: infrastructureStack.requireOutput("policyBlobName"),
+        checkpointBlobId: infrastructureStack.requireOutput("checkpointBlobId"),
+        checkpointBlobName: infrastructureStack.requireOutput("checkpointBlobName"),
+        storageAccountId: infrastructureStack.requireOutput("storageAccountId"),
+        apiDomain: stackConfig.require("apiDomain"),
+        consoleDomain: stackConfig.require("consoleDomain"),
+        tenantId: infrastructureStack.requireOutput("tenantId"),
+        subscriptionId: infrastructureStack.requireOutput("subscriptionId").apply(s => <string>s),
+        clientId: infrastructureStack.requireOutput("adApplicationId"),
+        clientSecret: infrastructureStack.requireOutput("adApplicationSecret"),
+        storageKey: infrastructureStack.requireOutput("storagePrimaryKey"),
+        storageAccountName: infrastructureStack.requireOutput("storageAccountName"),
+        keyvaultKeyName: infrastructureStack.requireOutput("keyvaultKeyName"),
+        keyvaultKeyVersion: infrastructureStack.requireOutput("keyvaultKeyVersion"),
+        keyvaultUri: infrastructureStack.requireOutput("keyvaultUri"),
+        smtpServer: stackConfig.get("smtpServer") || "",
+        smtpUsername: stackConfig.get("smtpUsername") || "",
+        smtpPassword: stackConfig.getSecret("smtpPassword") || "",
+        smtpFromAddress: stackConfig.get("smtpFromAddress") || "message@pulumi.com",
+        recaptchaSecretKey: stackConfig.getSecret("recaptchaSecretKey") ?? defaultRecaptchaSecretKey,
+        recaptchaSiteKey: stackConfig.get("recaptchaSiteKey") ?? defaultRecaptchaSiteKey,
+        samlEnabled: stackConfig.get("samlEnabled") || "false",
+        ingressAllowList: stackConfig.get("ingressAllowList") || "",
+        apiTlsKey,
+        apiTlsCert,
+        consoleTlsKey,
+        consoleTlsCert,
+        enableAzureDnsCertManager,
+        azureDnsZone,
+        azureDnsZoneResourceGroup,
+        certManagerNamespace,
+        managedClientId,
+        certManagerEmail,
+    };
 };
+
+function getValue<T>(input: StackReferenceOutputDetails, defaultValue: T): T {
+    if (!input) {
+        return defaultValue;
+    }
+
+    if (input.value) {
+        return <T>input.value!;
+    }
+
+    if (input.secretValue) {
+        return <T>input.secretValue!;
+    }
+
+    return defaultValue;
+}

--- a/aks-hosted/03-application/index.ts
+++ b/aks-hosted/03-application/index.ts
@@ -1,395 +1,420 @@
 import { interpolate, all, Input } from "@pulumi/pulumi";
 import { Provider, core, apps, networking } from "@pulumi/kubernetes";
-import { config } from "./config";
+import { getConfig } from "./config";
 import { SecretsCollection } from "./secrets";
 import { SsoCertificate } from "./sso-cert";
+import { CertManagerDeployment } from "./cert-manager";
 
-/**
+export = async () => {
+  /**
  * Check pre-requisites.
  */
-if (!config.apiDomain.startsWith("api.")) {
-  throw new Error("Configuration value [apiDomain] must start with [api.].")
-}
-if (!config.consoleDomain.startsWith("app.")) {
-  throw new Error("Configuration value [consoleDomain] must start with [app.].")
-}
-
-const commonName = "pulumi-selfhosted";
-
-const apiName = "pulumi-api";
-const apiAppLabel = { app: apiName };
-const consoleName = "pulumi-console";
-const consoleAppLabel = { app: consoleName };
-const apiResources = { requests: { cpu: "2048m", memory: "1024Mi" } };
-const consoleResources = { requests: { cpu: "1024m", memory: "512Mi" } };
-const migrationResources = { requests: { cpu: "128m", memory: "128Mi" } };
-
-const provider = new Provider("k8s-provider", {
-  kubeconfig: config.kubeconfig,
-});
-
-const appsNamespace = new core.v1.Namespace(`${commonName}-apps`, {
-  metadata: {
-    name: `${commonName}-apps`,
-  },
-}, { provider });
-
-const secrets = new SecretsCollection(`${commonName}-secrets`, {
-  apiDomain: config.apiDomain,
-  commonName: commonName,
-  namespace: appsNamespace.metadata.name,
-  provider: provider,
-  secretValues: {
-    apiTlsCert: config.apiTlsCert,
-    apiTlsKey: config.apiTlsKey,
-    consoleTlsCert: config.consoleTlsCert,
-    consoleTlsKey: config.consoleTlsKey,
-    database: {
-      connectionString: config.database.connectionString,
-      login: config.database.login,
-      password: config.database.password,
-      serverName: config.database.serverName
-    },
-    licenseKey: config.licenseKey,
-    smtpDetails: {
-      smtpServer: config.smtpServer,
-      smtpUsername: config.smtpUsername,
-      smtpPassword: config.smtpPassword,
-      smtpFromAddress: config.smtpFromAddress,
-    },
-    recaptcha: {
-      secretKey: config.recaptchaSecretKey,
-      siteKey: config.recaptchaSiteKey
-    }
+  const config = await getConfig();
+  if (!config.apiDomain.startsWith("api.")) {
+    throw new Error("Configuration value [apiDomain] must start with [api.].")
   }
-});
+  if (!config.consoleDomain.startsWith("app.")) {
+    throw new Error("Configuration value [consoleDomain] must start with [app.].")
+  }
 
-const ssoSecret = new SsoCertificate(`${commonName}-sso-certificate`, {
-  apiDomain: config.apiDomain,
-  namespace: appsNamespace.metadata.name,
-  provider: provider
-});
+  const commonName = "pulumi-selfhosted";
+  const apiName = "pulumi-api";
+  const apiAppLabel = { app: apiName };
+  const consoleName = "pulumi-console";
+  const consoleAppLabel = { app: consoleName };
+  const apiResources = { requests: { cpu: "2048m", memory: "1024Mi" } };
+  const consoleResources = { requests: { cpu: "1024m", memory: "512Mi" } };
+  const migrationResources = { requests: { cpu: "128m", memory: "128Mi" } };
 
-const apiPortName = "http";
-const apiDeployment = new apps.v1.Deployment(`${commonName}-${apiName}`, {
-  metadata: {
+  const provider = new Provider("k8s-provider", {
+    kubeconfig: config.kubeconfig,
+  });
+
+  const appsNamespace = new core.v1.Namespace(`${commonName}-apps`, {
+    metadata: {
+      name: `${commonName}-apps`,
+    },
+  }, { provider });
+
+  const secrets = new SecretsCollection(`${commonName}-secrets`, {
+    apiDomain: config.apiDomain,
+    commonName: commonName,
     namespace: appsNamespace.metadata.name,
-    name: `${apiName}-deployment`,
-  },
-  spec: {
-    selector: { matchLabels: apiAppLabel },
-    replicas: 1,
-    template: {
-      metadata: { labels: apiAppLabel },
-      spec: {
-        initContainers: [{
-          name: "pulumi-migration",
-          image: config.migrationImageName,
-          resources: migrationResources,
-          env: [
-            {
-              name: "PULUMI_DATABASE_ENDPOINT",
-              valueFrom: secrets.DBConnSecret.asEnvValue("host"),
-            },
-            {
-              name: "MYSQL_ROOT_USERNAME",
-              valueFrom: secrets.DBConnSecret.asEnvValue("username"),
-            },
-            {
-              name: "MYSQL_ROOT_PASSWORD",
-              valueFrom: secrets.DBConnSecret.asEnvValue("password"),
-            },
-            {
-              name: "PULUMI_DATABASE_PING_ENDPOINT",
-              valueFrom: secrets.DBConnSecret.asEnvValue("host"),
-            },
-            {
-              name: "RUN_MIGRATIONS_EXTERNALLY",
-              value: "true"
-            }
-          ]
-        }],
-        containers: [
-          {
-            name: apiName,
-            image: config.serviceImageName,
-            resources: apiResources,
-            ports: [{ containerPort: config.servicePort, name: apiPortName }],
+    provider: provider,
+    secretValues: {
+      apiTlsCert: config.apiTlsCert,
+      apiTlsKey: config.apiTlsKey,
+      consoleTlsCert: config.consoleTlsCert,
+      consoleTlsKey: config.consoleTlsKey,
+      database: {
+        connectionString: config.database.connectionString,
+        login: config.database.login,
+        password: config.database.password,
+        serverName: config.database.serverName
+      },
+      licenseKey: config.licenseKey,
+      smtpDetails: {
+        smtpServer: config.smtpServer,
+        smtpUsername: config.smtpUsername,
+        smtpPassword: config.smtpPassword,
+        smtpFromAddress: config.smtpFromAddress,
+      },
+      recaptcha: {
+        secretKey: config.recaptchaSecretKey,
+        siteKey: config.recaptchaSiteKey
+      }
+    }
+  });
+
+  const ssoSecret = new SsoCertificate(`${commonName}-sso-certificate`, {
+    apiDomain: config.apiDomain,
+    namespace: appsNamespace.metadata.name,
+    provider: provider
+  });
+
+  const apiPortName = "http";
+  const apiDeployment = new apps.v1.Deployment(`${commonName}-${apiName}`, {
+    metadata: {
+      namespace: appsNamespace.metadata.name,
+      name: `${apiName}-deployment`,
+    },
+    spec: {
+      selector: { matchLabels: apiAppLabel },
+      replicas: 1,
+      template: {
+        metadata: { labels: apiAppLabel },
+        spec: {
+          initContainers: [{
+            name: "pulumi-migration",
+            image: config.migrationImageName,
+            resources: migrationResources,
             env: [
-              {
-                name: "PULUMI_LICENSE_KEY",
-                valueFrom: secrets.LicenseKeySecret.asEnvValue("key"),
-              },
-              {
-                name: "PULUMI_ENTERPRISE",
-                value: "true",
-              },
-              {
-                name: "PULUMI_API_DOMAIN",
-                value: config.apiDomain,
-              },
-              {
-                name: "PULUMI_CONSOLE_DOMAIN",
-                value: config.consoleDomain,
-              },
               {
                 name: "PULUMI_DATABASE_ENDPOINT",
                 valueFrom: secrets.DBConnSecret.asEnvValue("host"),
               },
               {
-                name: "PULUMI_DATABASE_USER_NAME",
+                name: "MYSQL_ROOT_USERNAME",
                 valueFrom: secrets.DBConnSecret.asEnvValue("username"),
               },
               {
-                name: "PULUMI_DATABASE_USER_PASSWORD",
+                name: "MYSQL_ROOT_PASSWORD",
                 valueFrom: secrets.DBConnSecret.asEnvValue("password"),
               },
               {
-                name: "PULUMI_DATABASE_NAME",
-                value: "pulumi",
+                name: "PULUMI_DATABASE_PING_ENDPOINT",
+                valueFrom: secrets.DBConnSecret.asEnvValue("host"),
               },
               {
-                name: "SAML_CERTIFICATE_PUBLIC_KEY",
-                valueFrom: ssoSecret.SamlSsoSecret.asEnvValue("pubkey")
-              },
-              {
-                name: "SAML_CERTIFICATE_PRIVATE_KEY",
-                valueFrom: ssoSecret.SamlSsoSecret.asEnvValue("privatekey")
-              },
-              {
-                name: "AZURE_CLIENT_ID",
-                value: config.clientId
-              },
-              {
-                name: "AZURE_CLIENT_SECRET",
-                value: config.clientSecret
-              },
-              {
-                name: "AZURE_TENANT_ID",
-                value: config.tenantId
-              },
-              {
-                name: "AZURE_SUBSCRIPTION_ID",
-                value: config.subscriptionId
-              },
-              {
-                name: "AZURE_STORAGE_KEY",
-                value: config.storageKey
-              },
-              {
-                name: "PULUMI_POLICY_PACK_BLOB_STORAGE_ENDPOINT",
-                value: interpolate`azblob://${config.policyBlobName}`
-              },
-              {
-                name: "PULUMI_CHECKPOINT_BLOB_STORAGE_ENDPOINT",
-                value: interpolate`azblob://${config.checkpointBlobName}`
-              },
-              {
-                name: "AZURE_STORAGE_ACCOUNT",
-                value: config.storageAccountName
-              },
-              {
-                name: "PULUMI_AZURE_KV_URI",
-                value: config.keyvaultUri
-              },
-              {
-                name: "PULUMI_AZURE_KV_KEY_NAME",
-                value: config.keyvaultKeyName
-              },
-              {
-                name: "PULUMI_AZURE_KV_KEY_VERSION",
-                value: config.keyvaultKeyVersion
-              },
-              {
-                name: "SMTP_SERVER",
-                valueFrom: secrets.SmtpSecret.asEnvValue("server"),
-              },
-              {
-                name: "SMTP_USERNAME",
-                valueFrom: secrets.SmtpSecret.asEnvValue("username"),
-              },
-              {
-                name: "SMTP_PASSWORD",
-                valueFrom: secrets.SmtpSecret.asEnvValue("password"),
-              },
-              {
-                name: "SMTP_GENERIC_SENDER",
-                valueFrom: secrets.SmtpSecret.asEnvValue("fromaddress")
-              },
-              {
-                name: "RECAPTCHA_SECRET_KEY",
-                valueFrom: secrets.RecaptchaSecret.asEnvValue("secretKey")
-              },
-              {
-                name: "LOGIN_RECAPTCHA_SECRET_KEY",
-                valueFrom: secrets.RecaptchaSecret.asEnvValue("secretKey")
+                name: "RUN_MIGRATIONS_EXTERNALLY",
+                value: "true"
               }
-            ],
-          },
-        ],
+            ]
+          }],
+          containers: [
+            {
+              name: apiName,
+              image: config.serviceImageName,
+              resources: apiResources,
+              ports: [{ containerPort: config.servicePort, name: apiPortName }],
+              env: [
+                {
+                  name: "PULUMI_LICENSE_KEY",
+                  valueFrom: secrets.LicenseKeySecret.asEnvValue("key"),
+                },
+                {
+                  name: "PULUMI_ENTERPRISE",
+                  value: "true",
+                },
+                {
+                  name: "PULUMI_API_DOMAIN",
+                  value: config.apiDomain,
+                },
+                {
+                  name: "PULUMI_CONSOLE_DOMAIN",
+                  value: config.consoleDomain,
+                },
+                {
+                  name: "PULUMI_DATABASE_ENDPOINT",
+                  valueFrom: secrets.DBConnSecret.asEnvValue("host"),
+                },
+                {
+                  name: "PULUMI_DATABASE_USER_NAME",
+                  valueFrom: secrets.DBConnSecret.asEnvValue("username"),
+                },
+                {
+                  name: "PULUMI_DATABASE_USER_PASSWORD",
+                  valueFrom: secrets.DBConnSecret.asEnvValue("password"),
+                },
+                {
+                  name: "PULUMI_DATABASE_NAME",
+                  value: "pulumi",
+                },
+                {
+                  name: "SAML_CERTIFICATE_PUBLIC_KEY",
+                  valueFrom: ssoSecret.SamlSsoSecret.asEnvValue("pubkey")
+                },
+                {
+                  name: "SAML_CERTIFICATE_PRIVATE_KEY",
+                  valueFrom: ssoSecret.SamlSsoSecret.asEnvValue("privatekey")
+                },
+                {
+                  name: "AZURE_CLIENT_ID",
+                  value: config.clientId
+                },
+                {
+                  name: "AZURE_CLIENT_SECRET",
+                  value: config.clientSecret
+                },
+                {
+                  name: "AZURE_TENANT_ID",
+                  value: config.tenantId
+                },
+                {
+                  name: "AZURE_SUBSCRIPTION_ID",
+                  value: config.subscriptionId
+                },
+                {
+                  name: "AZURE_STORAGE_KEY",
+                  value: config.storageKey
+                },
+                {
+                  name: "PULUMI_POLICY_PACK_BLOB_STORAGE_ENDPOINT",
+                  value: interpolate`azblob://${config.policyBlobName}`
+                },
+                {
+                  name: "PULUMI_CHECKPOINT_BLOB_STORAGE_ENDPOINT",
+                  value: interpolate`azblob://${config.checkpointBlobName}`
+                },
+                {
+                  name: "AZURE_STORAGE_ACCOUNT",
+                  value: config.storageAccountName
+                },
+                {
+                  name: "PULUMI_AZURE_KV_URI",
+                  value: config.keyvaultUri
+                },
+                {
+                  name: "PULUMI_AZURE_KV_KEY_NAME",
+                  value: config.keyvaultKeyName
+                },
+                {
+                  name: "PULUMI_AZURE_KV_KEY_VERSION",
+                  value: config.keyvaultKeyVersion
+                },
+                {
+                  name: "SMTP_SERVER",
+                  valueFrom: secrets.SmtpSecret.asEnvValue("server"),
+                },
+                {
+                  name: "SMTP_USERNAME",
+                  valueFrom: secrets.SmtpSecret.asEnvValue("username"),
+                },
+                {
+                  name: "SMTP_PASSWORD",
+                  valueFrom: secrets.SmtpSecret.asEnvValue("password"),
+                },
+                {
+                  name: "SMTP_GENERIC_SENDER",
+                  valueFrom: secrets.SmtpSecret.asEnvValue("fromaddress")
+                },
+                {
+                  name: "RECAPTCHA_SECRET_KEY",
+                  valueFrom: secrets.RecaptchaSecret.asEnvValue("secretKey")
+                },
+                {
+                  name: "LOGIN_RECAPTCHA_SECRET_KEY",
+                  valueFrom: secrets.RecaptchaSecret.asEnvValue("secretKey")
+                }
+              ],
+            },
+          ],
+        },
       },
     },
-  },
-}, { provider });
+  }, { provider });
 
-const apiService = new core.v1.Service(`${commonName}-${apiName}`, {
-  metadata: {
-    name: `${apiName}-service`,
-    namespace: appsNamespace.metadata.name,
-  },
-  spec: {
-    ports: [{ port: 80, targetPort: config.servicePort, name: apiPortName }],
-    selector: apiAppLabel,
-  },
-}, { provider, parent: apiDeployment });
+  const apiService = new core.v1.Service(`${commonName}-${apiName}`, {
+    metadata: {
+      name: `${apiName}-service`,
+      namespace: appsNamespace.metadata.name,
+    },
+    spec: {
+      ports: [{ port: 80, targetPort: config.servicePort, name: apiPortName }],
+      selector: apiAppLabel,
+    },
+  }, { provider, parent: apiDeployment });
 
-const apiServiceEndpoint = core.v1.Endpoints.get("apiServiceEndpoints", apiService.id, { provider })
-const apiServiceEndpointAddress = apiServiceEndpoint.subsets[0].addresses[0].ip;
-const apiServiceEndpointPort = apiServiceEndpoint.subsets[0].ports[0].port;
+  const apiServiceEndpoint = core.v1.Endpoints.get("apiServiceEndpoints", apiService.id, { provider })
+  const apiServiceEndpointAddress = apiServiceEndpoint.subsets[0].addresses[0].ip;
+  const apiServiceEndpointPort = apiServiceEndpoint.subsets[0].ports[0].port;
 
-const consolePortName = "http-port";
-const consoleDeployment = new apps.v1.Deployment(`${commonName}-${consoleName}`, {
-  metadata: {
-    namespace: appsNamespace.metadata.name,
-    name: `${consoleName}-deployment`,
-  },
-  spec: {
-    selector: { matchLabels: consoleAppLabel },
-    replicas: 1,
-    template: {
-      metadata: { labels: consoleAppLabel },
-      spec: {
-        containers: [{
-          image: config.consoleImageName,
-          name: consoleName,
-          resources: consoleResources,
-          ports: [{ containerPort: config.consolePort, name: consolePortName }],
-          env: [
-            {
-              name: "PULUMI_CONSOLE_DOMAIN",
-              value: config.consoleDomain
-            },
-            {
-              name: "PULUMI_HOMEPAGE_DOMAIN",
-              value: config.consoleDomain
-            },
-            {
-              name: "SAML_SSO_ENABLED",
-              value: config.samlEnabled
-            },
-            {
-              name: "PULUMI_API",
-              value: interpolate`https://${config.apiDomain}`
-            },
-            {
-              name: "PULUMI_API_INTERNAL_ENDPOINT",
-              value: interpolate`http://${apiServiceEndpointAddress}:${apiServiceEndpointPort}`
-            },
-            {
-              name: "RECAPTCHA_SITE_KEY",
-              valueFrom: secrets.RecaptchaSecret.asEnvValue("siteKey")
-            },
-            {
-              name: "LOGIN_RECAPTCHA_SITE_KEY",
-              valueFrom: secrets.RecaptchaSecret.asEnvValue("siteKey")
-            }
-          ]
-        }]
+  const consolePortName = "http-port";
+  const consoleDeployment = new apps.v1.Deployment(`${commonName}-${consoleName}`, {
+    metadata: {
+      namespace: appsNamespace.metadata.name,
+      name: `${consoleName}-deployment`,
+    },
+    spec: {
+      selector: { matchLabels: consoleAppLabel },
+      replicas: 1,
+      template: {
+        metadata: { labels: consoleAppLabel },
+        spec: {
+          containers: [{
+            image: config.consoleImageName,
+            name: consoleName,
+            resources: consoleResources,
+            ports: [{ containerPort: config.consolePort, name: consolePortName }],
+            env: [
+              {
+                name: "PULUMI_CONSOLE_DOMAIN",
+                value: config.consoleDomain
+              },
+              {
+                name: "PULUMI_HOMEPAGE_DOMAIN",
+                value: config.consoleDomain
+              },
+              {
+                name: "SAML_SSO_ENABLED",
+                value: config.samlEnabled
+              },
+              {
+                name: "PULUMI_API",
+                value: interpolate`https://${config.apiDomain}`
+              },
+              {
+                name: "PULUMI_API_INTERNAL_ENDPOINT",
+                value: interpolate`http://${apiServiceEndpointAddress}:${apiServiceEndpointPort}`
+              },
+              {
+                name: "RECAPTCHA_SITE_KEY",
+                valueFrom: secrets.RecaptchaSecret.asEnvValue("siteKey")
+              },
+              {
+                name: "LOGIN_RECAPTCHA_SITE_KEY",
+                valueFrom: secrets.RecaptchaSecret.asEnvValue("siteKey")
+              }
+            ]
+          }]
+        }
       }
     }
+  }, { provider });
+
+  const consoleService = new core.v1.Service(`${commonName}-${consoleName}`, {
+    metadata: {
+      name: `${consoleName}-service`,
+      namespace: appsNamespace.metadata.name,
+    },
+    spec: {
+      ports: [{ port: 80, targetPort: config.consolePort, name: consolePortName }],
+      selector: consoleAppLabel,
+    },
+  }, { provider, parent: consoleDeployment });
+
+  let ingressAnnotations: Input<{
+    [key: string]: Input<string>;
+  }> = {
+    "nginx.ingress.kubernetes.io/proxy-body-size": "50m",
+  };
+
+  if (config.ingressAllowList.length > 0) {
+    ingressAnnotations["nginx.ingress.kubernetes.io/whitelist-source-range"] = config.ingressAllowList;
   }
-}, { provider });
 
-const consoleService = new core.v1.Service(`${commonName}-${consoleName}`, {
-  metadata: {
-    name: `${consoleName}-service`,
+  const certSecretName = `${commonName}-tls`;
+  if (config.enableAzureDnsCertManager) {
+    const cert = new CertManagerDeployment(commonName, {
+      provider,
+      domains: [
+        config.consoleDomain,
+        config.apiDomain
+      ],
+      namespaceName: appsNamespace.metadata.name,
+      certSecretName: certSecretName,
+      resourceGroupName: config.azureDnsZoneResourceGroup,
+      hostedZoneName: config.azureDnsZone,
+      managedClientId: config.managedClientId,
+      subscriptionId: config.subscriptionId,
+      issuerEmail: config.certManagerEmail,
+    });
+  }
+
+  new networking.v1.Ingress(`${commonName}-ingress`, {
+    metadata: {
+      name: "pulumi-service-ingress",
+      namespace: appsNamespace.metadata.name,
+      annotations: ingressAnnotations,
+    },
+    spec: {
+      ingressClassName: "nginx",
+      defaultBackend: {
+        service: {
+          name: consoleService.metadata.name,
+          port: {
+            number: 80
+          }
+        }
+      },
+      tls: [
+        {
+          hosts: [config.consoleDomain],
+          secretName: config.enableAzureDnsCertManager ? certSecretName : secrets.ConsoleCertificateSecret?.metadata.name,
+        },
+        {
+          hosts: [config.apiDomain],
+          secretName: config.enableAzureDnsCertManager ? certSecretName : secrets.ApiCertificateSecret?.metadata.name,
+        }
+      ],
+      rules: [
+        {
+          host: config.apiDomain,
+          http: {
+            paths: [
+              {
+                path: "/",
+                pathType: "Prefix",
+                backend: {
+                  service: {
+                    name: apiService.metadata.name,
+                    port: {
+                      name: apiPortName,
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          host: config.consoleDomain,
+          http: {
+            paths: [
+              {
+                path: "/",
+                pathType: "Prefix",
+                backend: {
+                  service: {
+                    name: consoleService.metadata.name,
+                    port: {
+                      name: consolePortName,
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }, { provider: provider });
+
+  return {
+    consoleUrl: interpolate`https://${config.consoleDomain}`,
+    apiUrl: interpolate`https://${config.apiDomain}`,
     namespace: appsNamespace.metadata.name,
-  },
-  spec: {
-    ports: [{ port: 80, targetPort: config.consolePort, name: consolePortName }],
-    selector: consoleAppLabel,
-  },
-}, { provider, parent: consoleDeployment });
-
-let ingressAnnotations: Input<{
-  [key: string]: Input<string>;
-}> = {
-  "nginx.ingress.kubernetes.io/proxy-body-size": "50m",
-};
-
-if(config.ingressAllowList.length > 0) {
-  ingressAnnotations["nginx.ingress.kubernetes.io/whitelist-source-range"] = config.ingressAllowList;
+  }
 }
 
-new networking.v1.Ingress(`${commonName}-ingress`, {
-  metadata: {
-    name: "pulumi-service-ingress",
-    namespace: appsNamespace.metadata.name,
-    annotations: ingressAnnotations,
-  },
-  spec: {
-    ingressClassName: "nginx",
-    defaultBackend: {
-      service: {
-        name: consoleService.metadata.name,
-        port: {
-          number: 80
-        }
-      }
-    },
-    tls: [
-      {
-        hosts: [config.consoleDomain],
-        secretName: secrets.ConsoleCertificateSecret.metadata.name,
-      },
-      {
-        hosts: [config.apiDomain],
-        secretName: secrets.ApiCertificateSecret.metadata.name,
-      }
-    ],
-    rules: [
-      {
-        host: config.apiDomain,
-        http: {
-          paths: [
-            {
-              path: "/",
-              pathType: "Prefix",
-              backend: {
-                service: {
-                  name: apiService.metadata.name,
-                  port: {
-                    name: apiPortName,
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      {
-        host: config.consoleDomain,
-        http: {
-          paths: [
-            {
-              path: "/",
-              pathType: "Prefix",
-              backend: {
-                service: {
-                  name: consoleService.metadata.name,
-                  port: {
-                    name: consolePortName,
-                  }
-                }
-              }
-            }
-          ]
-        }
-      }
-    ]
-  }
-}, { provider: provider });
 
-export const consoleUrl = interpolate`https://${config.consoleDomain}`;
-export const apiUrl = interpolate`https://${config.apiDomain}`;
-export const namespace = appsNamespace.metadata.name;

--- a/aks-hosted/README.md
+++ b/aks-hosted/README.md
@@ -68,7 +68,10 @@ To deploy entire stack, run the following in your terminal:
 1. `cd ../02-kubernetes`
 1. `npm install`
 1. `pulumi stack init {stackName2}` - see note above about NO NUMBERS in stack name
-1. `pulumi config set stackName1 {stackName1}`
+1. `pulumi config set stackName1 {stackName1}` 
+1. **OPTIONAL** `pulumi config set enableAzureDnsCertManagement true` **NOTE** this requires both `azureDnsZoneName` and `azureDnsZoneResourceGroup` to be set
+1. **OPTIONAL** if `enableAzureDnsCertManagement` is set then: `pulumi config set azureDnsZoneName {zone_name}`
+1. **OPTIONAL** if `enableAzureDnsCertManagement` is set then: `pulumi config set azureDnsZoneResourceGroup {resource_group_name}`
 1. `pulumi up`
 1. `cd ../03-application`
 1. `npm install`
@@ -87,13 +90,18 @@ To deploy entire stack, run the following in your terminal:
 
 The following settings are optional.  
 Note if not set, "forgot password" and email invites will not work but sign ups and general functionality will still work.
+1. `cat {path to api key file} | pulumi config set apiTlsKey --secret --` (on a mac or linux machine) **NOT REQUIRED IF CERT-MANAGER IS ENABLED**
+1. `cat {path to api cert file} | pulumi config set apiTlsCert --secret --` (on a mac or linux machine) **NOT REQUIRED IF CERT-MANAGER IS ENABLED**
+1. `cat {path to console key file} | pulumi config set consoleTlsKey --secret --` (on a mac or linux machine) **NOT REQUIRED IF CERT-MANAGER IS ENABLED**
+1. `cat {path to console cert file} | pulumi config set consoleTlsCert --secret --` (on a mac or linux machine) **NOT REQUIRED IF CERT-MANAGER IS ENABLED**
 1. `pulumi config set smtpServer {smtp server:port}` (for example: smtp.domain.com:587)
 1. `pulumi config set smtpUsername {smtp username}`
 1. `pulumi config set smtpPassword {smtp password} --secret`
 1. `pulumi config set smtpFromAddress {smtp from address}` (email address that the outgoing emails come from)
 1. `pulumi config set recaptchaSiteKey {recaptchaSiteKey}` (this must be a v2 type recaptcha)
 1. `pulumi config set recaptchaSecretKey {recaptchaSecretKey} --secret`
-1. `pulumi config set ingressAllowList {cidr range list}` (allow list of IPv4 CIDR ranges to allow access to the self-hosted Pulumi Cloud. Not setting this will allow the set up to be open to the internet). Proper formatting can be seen [here](https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#whitelist-source-range)
+1. `pulumi config set ingressAllowList {cidr range list}` (allow list of IPv4 CIDR ranges to allow access to the self-hosted Pulumi Cloud. Not setting this will allow the set up to be open to the internet). Proper formatting can be seen [here](https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#whitelist-source-range) 
+1. `pulumi config set certManagerEmail {email}` (email address that will be used for certificate expirations purposes from letsencrypt)
 1. `pulumi up`
 
 ### Configure DNS


### PR DESCRIPTION
Prior to this change, a user is required to provide the cert and key files for TLS certs to be used in connection with the api and the ui. This is not an ideal experience and requires manual steps which can be automated.

Noteworthy changes:
- [Use `network.GetVirtualNetworkOutput` instead of `network.VirtualNetwork.get`](https://github.com/pulumi/pulumi-self-hosted-installers/blob/c1a52e0e33a45508e360674bacbdfda4ebbeebf3/aks-hosted/01-infrastructure/network.ts#L28-L33)
- Add /aks-hosted/02-kubernetes/cert-manager.ts
- Enable oidc and workload identity [cluster](https://github.com/pulumi/pulumi-self-hosted-installers/blob/c1a52e0e33a45508e360674bacbdfda4ebbeebf3/aks-hosted/02-kubernetes/cluster.ts#L81-L91)
- Added [config](https://github.com/pulumi/pulumi-self-hosted-installers/blob/c1a52e0e33a45508e360674bacbdfda4ebbeebf3/aks-hosted/02-kubernetes/config.ts#L16-L22) for enabling cert manager bits.
- Add /aks-hosted/02-kubernetes/identity.ts
- Add /aks-hosted/02-kubernetes/cert-manager.ts
- Deploy identity/cert-manager based on [config boolean](https://github.com/pulumi/pulumi-self-hosted-installers/blob/c1a52e0e33a45508e360674bacbdfda4ebbeebf3/aks-hosted/02-kubernetes/index.ts#L37-L56)
- Add use of `getOutputDetails` in /aks-hosted/03-application/config.ts
- Make api/console certs optional [from config](https://github.com/pulumi/pulumi-self-hosted-installers/blob/c1a52e0e33a45508e360674bacbdfda4ebbeebf3/aks-hosted/03-application/secrets.ts#L51-L73)
- /03-application/index.ts - lots of changes. Mainly to use top level async and deploy cert manager or config based tls certs