### PR TITLE
Use MySQL Flexible Server instead of Single Server w/ is EOL 2024

### DIFF
--- a/aks-hosted/.gitignore
+++ b/aks-hosted/.gitignore
@@ -4,3 +4,4 @@ temp
 Pulumi.*.yaml
 package-lock.json
 *.pem
+**/kubeconfig

--- a/aks-hosted/01-infrastructure/config.ts
+++ b/aks-hosted/01-infrastructure/config.ts
@@ -7,7 +7,12 @@ const stackName = pulumi.getStack();
 const commonName = "pulumiselfhosted" || stackConfig.get("commonName");
 const resourceNamePrefix = `${commonName}-${stackName}`;
 const disableAutoNaming = stackConfig.getBoolean("disableAutoNaming");
+
+// subnet for AKS cluster
 const subnetCidr = stackConfig.require("subnetCidr");
+
+// dedicated subnet (delegated) for MySQL databases
+const dbSubnetCidr = stackConfig.require("dbSubnetCidr");
 const networkCidr = stackConfig.get("networkCidr");
 
 // if a user does elect to BYO vnet, they will be required to also supply the resource group name that houses the vnet
@@ -29,6 +34,7 @@ export const config = {
   disableAutoNaming,
   networkCidr,
   subnetCidr,
+  dbSubnetCidr,
   vnetName,
   vnetResourceGroup,
   baseTags: {

--- a/aks-hosted/01-infrastructure/database.ts
+++ b/aks-hosted/01-infrastructure/database.ts
@@ -1,23 +1,47 @@
-import { dbformysql } from "@pulumi/azure-native";
+import { dbformysql, network } from "@pulumi/azure-native";
 import * as random from "@pulumi/random";
-import { Input, Output, ComponentResource, ComponentResourceOptions } from "@pulumi/pulumi";
+import { Input, Output, ComponentResource, ComponentResourceOptions, interpolate } from "@pulumi/pulumi";
 
 export interface DatabaseArgs {
     resourceGroupName: Output<string>,
-    subnetId: Output<string>,
+    vnetId: Output<string>,
+    dbSubnetId: Output<string>,
+    aksSubnetId: Output<string>,
     tags?: Input<{
         [key: string]: Input<string>;
-    }>,
+    }>
 }
 
 export class Database extends ComponentResource {
-    DatabaseConnectionString: Output<string | undefined>;
+    DatabaseEndpoint: Output<string | undefined>;
     DatabaseLogin: Output<string | undefined>;
     DatabasePassword: Output<string>;
     DatabaseName: Output<string>;
     DatabaseServerName: Output<string>;
     constructor(name: string, args: DatabaseArgs, opts?: ComponentResourceOptions) {
         super("x:infrastructure:database", name, opts);
+
+        // to allow us to limit DB access to our VNET only, we'll use PrivateDNS
+        // we require a unique server zone name to tie a PrivateDNS Zone to our DB
+        const serverName = name;
+        // const serverZoneName = `${serverName}.private.mysql.database.azure.com`
+        const privateZone = new network.PrivateZone(`${name}-private-zone`, {
+            resourceGroupName: args.resourceGroupName,
+            privateZoneName: "private.mysql.database.azure.com",
+            location: "global",
+        }, { parent: this });
+
+        // link our vnet and private DNS zone
+        // MySQL server will automatically handle DNS needs for DB server
+        const vnetLink = new network.VirtualNetworkLink(`${name}-private-link`, {
+            resourceGroupName: args.resourceGroupName,
+            privateZoneName: privateZone.name,
+            registrationEnabled: false,
+            location: "global",
+            virtualNetwork: {
+                id: args.vnetId,
+            }
+        }, { parent: this });
 
         const dbPassword = new random.RandomPassword(`${name}-dbpassword`, {
             length: 20,
@@ -29,35 +53,40 @@ export class Database extends ComponentResource {
             additionalSecretOutputs: ["result"],
         });
 
+        // It is not explicit, but create a MySQL Flexible server (not single)
+        const adminLogin = "pulumiadmin";
         const server = new dbformysql.Server(`${name}-mysql`, {
+            administratorLogin: adminLogin,
+            administratorLoginPassword: dbPassword.result,
             resourceGroupName: args.resourceGroupName,
-            properties: {
-                administratorLogin: "pulumiadmin",
-                administratorLoginPassword: dbPassword.result,
-                createMode: "Default",
-                infrastructureEncryption: "Disabled",
-                minimalTlsVersion: "TLSEnforcementDisabled",
-                publicNetworkAccess: "Enabled", // allow traffic from vnet (not public) based on firewall rule below;
-                sslEnforcement: "Disabled",
-                storageProfile: {
-                    backupRetentionDays: 7,
-                    geoRedundantBackup: "Disabled",
-                    storageAutogrow: "Enabled",
-                    storageMB: 51200,
-                },
-                version: "8.0",
+            network: {
+                delegatedSubnetResourceId: args.dbSubnetId,
+                privateDnsZoneResourceId: privateZone.id,
             },
+            storage: {
+                storageSizeGB: 50,
+                autoGrow: "Enabled",
+            },
+            version: "8.0.21",
             sku: {
-                capacity: 4,
-                family: "Gen5",
-                name: "GP_Gen5_4",
+                name: "Standard_D2ads_v5",
                 tier: "GeneralPurpose",
             },
             tags: args.tags,
         }, {
             protect: true,
-            parent: this
+            parent: this,
+            deleteBeforeReplace: true,
+            dependsOn: [vnetLink]
         });
+
+        // new dbformysql.Configuration(`${name}-disable-tls`, {
+        //     resourceGroupName: args.resourceGroupName,
+        //     serverName: server.name,  
+        //     source: "user-override",
+        //     configurationName: "require_secure_transport",
+        //     value: "OFF",
+        // }, { parent: server });
 
         // https://docs.microsoft.com/en-us/azure/mysql/howto-troubleshoot-common-errors#error-1419-you-do-not-have-the-super-privilege-and-binary-logging-is-enabled-you-might-want-to-use-the-less-safe-log_bin_trust_function_creators-variable
         new dbformysql.Configuration(`${name}-config`, {
@@ -66,13 +95,6 @@ export class Database extends ComponentResource {
             source: "user-override",
             configurationName: "log_bin_trust_function_creators",
             value: "ON",
-        }, { parent: server });
-
-        // this ensures access from vnet -> db
-        const vnetRule = new dbformysql.VirtualNetworkRule(`${name}-dbvnetrule`, {
-            resourceGroupName: args.resourceGroupName,
-            serverName: server.name,
-            virtualNetworkSubnetId: args.subnetId,
         }, { parent: server });
 
         const db = new dbformysql.Database(`${name}-mysql`, {
@@ -84,13 +106,13 @@ export class Database extends ComponentResource {
             protect: true,
         });
 
-        this.DatabaseConnectionString = server.fullyQualifiedDomainName;
+        this.DatabaseEndpoint = interpolate `${server.name}.${privateZone.name}`;
         this.DatabaseLogin = server.administratorLogin;
         this.DatabasePassword = dbPassword.result;
         this.DatabaseName = db.name;
         this.DatabaseServerName = server.name;
         this.registerOutputs({
-            DatabaseConnectionString: this.DatabaseConnectionString,
+            DatabaseEndpoint: this.DatabaseEndpoint,
             DatabaseLogin: this.DatabaseLogin,
             DatabasePassword: this.DatabasePassword,
             DatabaseName: this.DatabaseName,

--- a/aks-hosted/01-infrastructure/database.ts
+++ b/aks-hosted/01-infrastructure/database.ts
@@ -23,11 +23,9 @@ export class Database extends ComponentResource {
 
         // to allow us to limit DB access to our VNET only, we'll use PrivateDNS
         // we require a unique server zone name to tie a PrivateDNS Zone to our DB
-        const serverName = name;
-        // const serverZoneName = `${serverName}.private.mysql.database.azure.com`
         const privateZone = new network.PrivateZone(`${name}-private-zone`, {
             resourceGroupName: args.resourceGroupName,
-            privateZoneName: "private.mysql.database.azure.com",
+            privateZoneName: "pulumi.mysql.database.azure.com",
             location: "global",
         }, { parent: this });
 
@@ -80,13 +78,13 @@ export class Database extends ComponentResource {
             dependsOn: [vnetLink]
         });
 
-        // new dbformysql.Configuration(`${name}-disable-tls`, {
-        //     resourceGroupName: args.resourceGroupName,
-        //     serverName: server.name,  
-        //     source: "user-override",
-        //     configurationName: "require_secure_transport",
-        //     value: "OFF",
-        // }, { parent: server });
+        new dbformysql.Configuration(`${name}-disable-tls`, {
+            resourceGroupName: args.resourceGroupName,
+            serverName: server.name,  
+            source: "user-override",
+            configurationName: "require_secure_transport",
+            value: "OFF",
+        }, { parent: server });
 
         // https://docs.microsoft.com/en-us/azure/mysql/howto-troubleshoot-common-errors#error-1419-you-do-not-have-the-super-privilege-and-binary-logging-is-enabled-you-might-want-to-use-the-less-safe-log_bin_trust_function_creators-variable
         new dbformysql.Configuration(`${name}-config`, {

--- a/aks-hosted/01-infrastructure/keyStorage.ts
+++ b/aks-hosted/01-infrastructure/keyStorage.ts
@@ -72,7 +72,6 @@ export class KeyStorage extends ComponentResource {
 
         const key = new keyvault.Key(`${name}-key`, {
             resourceGroupName: args.resourceGroupName,
-
             properties: {
                 kty: keyvault.JsonWebKeyType.RSA
             },

--- a/aks-hosted/01-infrastructure/network.ts
+++ b/aks-hosted/01-infrastructure/network.ts
@@ -1,10 +1,10 @@
-import * as pulumi from "@pulumi/pulumi";
 import { network } from "@pulumi/azure-native";
 import { Input, Output, ComponentResource, log } from "@pulumi/pulumi";
 
 export interface NetworkArgs {
   resourceGroupName: Output<string>;
   subnetCidr: string;
+  dbSubnetCidr: string;
   networkCidr?: string;
   vnetName?: string;
   tags?: Input<{
@@ -14,6 +14,9 @@ export interface NetworkArgs {
 
 export class Network extends ComponentResource {
   public readonly subnetId: Output<string>;
+  public readonly dbSubnetId: Output<string>;
+  public readonly vnetId: Output<string>;
+
   constructor(name: string, args: NetworkArgs) {
     super("x:infrastructure:networking", name);
 
@@ -23,8 +26,9 @@ export class Network extends ComponentResource {
       throw new Error(err)
     }
 
-    // allow users to provide their own vnet, if they elect
+    // allow users to provide their own vnet, if they elect, but we will still create two subnets
     let vnetName: Output<string>;
+    let vnetId: Output<string>;
     if (args.vnetName) {
       const preExisting = network.getVirtualNetworkOutput({
         resourceGroupName: args.resourceGroupName,
@@ -32,6 +36,7 @@ export class Network extends ComponentResource {
       });
 
       vnetName = preExisting.name;
+      vnetId = preExisting.id!.apply(s => s!);
     } else {
       const vnet = new network.VirtualNetwork(`${name}-vnet`, {
         resourceGroupName: args.resourceGroupName,
@@ -41,20 +46,38 @@ export class Network extends ComponentResource {
         tags: args.tags,
       }, { parent: this, ignoreChanges: ["subnets", "etags"] }); // ignore changes due to https://github.com/pulumi/pulumi-azure-native/issues/611#issuecomment-721490800
       vnetName = vnet.name;
+      vnetId = vnet.id;
     }
 
     const subnet = new network.Subnet(`${name}-snet`, {
       resourceGroupName: args.resourceGroupName,
       virtualNetworkName: vnetName,
       addressPrefix: args.subnetCidr,
-      serviceEndpoints: [{
-        service: "Microsoft.Sql"
-      }],
+      privateLinkServiceNetworkPolicies: "Disabled",
+      privateEndpointNetworkPolicies: "Disabled",
+    }, { parent: this });
+
+    // subnet will be dedicated to mysql databases
+    // requires at minimum a /28
+    const dbSubnet = new network.Subnet(`${name}-db-snet`, {
+      resourceGroupName: args.resourceGroupName,
+      virtualNetworkName: vnetName,
+      addressPrefix: args.dbSubnetCidr,
+      privateLinkServiceNetworkPolicies: "Disabled",
+      privateEndpointNetworkPolicies: "Disabled",
+      delegations: [{
+        name: "db-delegation-1",
+        serviceName: "Microsoft.DBforMySQL/flexibleServers", // delegation marks this as MySQL flexible server only
+      }]
     }, { parent: this });
 
     this.subnetId = subnet.id;
+    this.dbSubnetId = dbSubnet.id;
+    this.vnetId = vnetId;
     this.registerOutputs({
       SubnetId: this.subnetId,
+      DbSubnetId: this.dbSubnetId,
+      VnetId: this.vnetId,
     });
   }
 }

--- a/aks-hosted/01-infrastructure/package.json
+++ b/aks-hosted/01-infrastructure/package.json
@@ -1,10 +1,10 @@
 {
     "name": "k8s-azure-01-infrastructure",
     "devDependencies": {
-        "@types/node": "^10.0.0"
+        "@types/node": "^16.0.0"
     },
     "dependencies": {
-        "@pulumi/azure-native": "^1.2.0",
+        "@pulumi/azure-native": "v2.0.0-beta.2",
         "@pulumi/azuread": "^4.0.0",
         "@pulumi/pulumi": "^3.1.0",
         "@pulumi/random": "^4.0.0"

--- a/aks-hosted/01-infrastructure/storage.ts
+++ b/aks-hosted/01-infrastructure/storage.ts
@@ -24,26 +24,26 @@ export class Storage extends ComponentResource {
         const storageAccount = new storage.StorageAccount("pulumi", {
             resourceGroupName: args.resourceGroupName,
             sku: {
-                name: storage.v20190601.SkuName.Standard_LRS,
+                name: storage.SkuName.Standard_LRS,
             },
-            kind: storage.v20190601.Kind.StorageV2,
+            kind: storage.Kind.StorageV2,
             tags: args.tags,
-        }, {parent: this, protect: true});
+        }, { parent: this, protect: true });
 
         const checkpointBlob = new storage.BlobContainer(`pulumicheckpoints`, {
             resourceGroupName: args.resourceGroupName,
             accountName: storageAccount.name,
-        }, {parent: storageAccount, protect: true});
-        
+        }, { parent: storageAccount, protect: true });
+
         const policyBlob = new storage.BlobContainer(`pulumipolicypacks`, {
             resourceGroupName: args.resourceGroupName,
             accountName: storageAccount.name,
-        }, {parent: storageAccount, protect: true});
+        }, { parent: storageAccount, protect: true });
 
-        const storageAccountKeys = all([args.resourceGroupName, storageAccount.name])
-            .apply(([resourceGroupName, accountName]) =>
-                storage.v20190601.listStorageAccountKeys({ resourceGroupName, accountName })
-            );
+        const storageAccountKeys = storage.listStorageAccountKeysOutput({
+            resourceGroupName: args.resourceGroupName,
+            accountName: storageAccount.name,
+        });
 
         this.storageAccountKey1 = secret(storageAccountKeys.keys[0].value);
         this.storageAccountKey2 = secret(storageAccountKeys.keys[1].value);
@@ -53,7 +53,7 @@ export class Storage extends ComponentResource {
         this.checkpointBlobName = checkpointBlob.name;
         this.policyBlobName = policyBlob.name;
         this.storageAccountName = storageAccount.name;
-        
+
         this.registerOutputs({
             storageAccountId: this.storageAccountId,
             storageAccountKey1: this.storageAccountKey1,

--- a/aks-hosted/02-kubernetes/cluster.ts
+++ b/aks-hosted/02-kubernetes/cluster.ts
@@ -8,7 +8,7 @@ interface KubernetesClusterArgs {
   aDApplicationId: Output<string>;
   aDApplicationSecret: Output<string>;
   aDAdminGroupId: Output<string>;
-  enableAzureDnsCertManagement: boolean;
+  disableAzureDnsCertManagement: boolean;
   tags?: Input<{
     [key: string]: Input<string>;
   }>,
@@ -78,7 +78,7 @@ export class KubernetesCluster extends ComponentResource {
     // this props will allow use to deploy cert-manager using azure managed identity
     // ultimately, the cert-manager pods will be able to use this ID to securely work with
     // azure DNS resources to ensure our certs are automatically verified.
-    if (args.enableAzureDnsCertManagement) {
+    if (!args.disableAzureDnsCertManagement) {
       clusterArgs.oidcIssuerProfile = {
         enabled: true
       };
@@ -92,7 +92,6 @@ export class KubernetesCluster extends ComponentResource {
 
     // Must use a shorter name due to https://aka.ms/aks-naming-rules.
     const cluster = new containerservice.v20230102preview.ManagedCluster(`${name}-aks`, clusterArgs, { parent: this, protect: true });
-
     const nodeResourceGroup = cluster.nodeResourceGroup.apply(s => s!);
     const publicIp = new network.PublicIPAddress(`${name}-publicIp`, {
       resourceGroupName: nodeResourceGroup,

--- a/aks-hosted/02-kubernetes/config.ts
+++ b/aks-hosted/02-kubernetes/config.ts
@@ -13,10 +13,10 @@ const resourceNamePrefix = `${commonName}-${stackName}`;
 
 // if enabled, this boolean controls whether or not cert-manager will be deployed and managed identity created for workloads to assume
 // while this is the preferred way of managing certs, it is not required
-const enableAzureDnsCertManagement = stackConfig.getBoolean("enableAzureDnsCertManagement") || false;
+const disableAzureDnsCertManagement = stackConfig.getBoolean("disableAzureDnsCertManagement") || false;
 let azureDnsZoneName = undefined;
 let azureDnsZoneResourceGroup = undefined;
-if (enableAzureDnsCertManagement) {
+if (!disableAzureDnsCertManagement) {
     azureDnsZoneName = stackConfig.require("azureDnsZoneName");
     azureDnsZoneResourceGroup = stackConfig.require("azureDnsZoneResourceGroup");
 }
@@ -25,7 +25,7 @@ export const config = {
     projectName,
     stackName,
     resourceNamePrefix,
-    enableAzureDnsCertManagement,
+    disableAzureDnsCertManagement,
     azureDnsZoneName,
     azureDnsZoneResourceGroup,
     baseTags: {

--- a/aks-hosted/02-kubernetes/index.ts
+++ b/aks-hosted/02-kubernetes/index.ts
@@ -13,7 +13,7 @@ const cluster = new KubernetesCluster(`${config.resourceNamePrefix}`, {
     aDApplicationSecret: config.adApplicationSecret,
     resourceGroupName: config.resourceGroupName,
     tags: config.baseTags,
-    enableAzureDnsCertManagement: config.enableAzureDnsCertManagement,
+    disableAzureDnsCertManagement: config.disableAzureDnsCertManagement,
 });
 
 export const kubeconfig = secret(cluster.Kubeconfig);
@@ -34,7 +34,7 @@ let certManagerNs: Output<string> | undefined;
 // this props will allow use to deploy cert-manager using azure managed identity
 // ultimately, the cert-manager pods will be able to use this ID to securely work with
 // azure DNS resources to ensure our certs are automatically verified.
-if (config.enableAzureDnsCertManagement) {
+if (!config.disableAzureDnsCertManagement) {
     const certManager = new CertManager("pulumi-selfhosted", {
         provider,
         certManagerNamespaceName,
@@ -60,7 +60,7 @@ export const ingressNamespace = ingress.IngressNamespace;
 export const stackName2 = config.stackName;
 
 // this will enable cert-manager deployments using letsencrypt in the 03 project
-export const enableAzureDnsCertManagement = config.enableAzureDnsCertManagement;
+export const disableAzureDnsCertManagement = config.disableAzureDnsCertManagement;
 export const certManagerNamespace = certManagerNs;
 export const azureDnsZone = config.azureDnsZoneName;
 export const azureDnsZoneResourceGroup = config.azureDnsZoneResourceGroup;

--- a/aks-hosted/02-kubernetes/package.json
+++ b/aks-hosted/02-kubernetes/package.json
@@ -4,7 +4,7 @@
         "@types/node": "^10.0.0"
     },
     "dependencies": {
-        "@pulumi/azure-native": "^1.2.0",
+        "@pulumi/azure-native": "^1.103.0",
         "@pulumi/azuread": "^4.0.0",
         "@pulumi/kubernetes": "^3.0.0",
         "@pulumi/pulumi": "^3.1.0",

--- a/aks-hosted/03-application/cert-manager.ts
+++ b/aks-hosted/03-application/cert-manager.ts
@@ -17,9 +17,9 @@ export class CertManagerDeployment extends ComponentResource {
     constructor(name: string, args: CertManagerArgs, opts?: ComponentResourceOptions) {
         super("x:kubernetes:certManagerDeployment", name, args, opts);
 
-        const letsEncryptUrl = "https://acme-v02.api.letsencrypt.org/directory";
+        //  const letsEncryptUrl = "https://acme-v02.api.letsencrypt.org/directory";
         // FOR TESTING:
-        // const letsEncryptUrl = "https://acme-staging-v02.api.letsencrypt.org/directory";
+        const letsEncryptUrl = "https://acme-staging-v02.api.letsencrypt.org/directory";
         const acmeSpec = args.issuerEmail ?
             {
                 server: letsEncryptUrl,

--- a/aks-hosted/03-application/config.ts
+++ b/aks-hosted/03-application/config.ts
@@ -23,8 +23,8 @@ export const getConfig = async () => {
 
     // the below enableAzureDnsCertManagement will cause the legacy certs and keys to be ignored as well ass
     // a cluster issuer and cert created using letsencrypt w/ DNs01 validation via Azure DNS
-    const enableAzureDnsCertManagementValue = await clusterStack.getOutputDetails("enableAzureDnsCertManagement");
-    const enableAzureDnsCertManager = getValue<boolean>(enableAzureDnsCertManagementValue, false);
+    const enableAzureDnsCertManagementValue = await clusterStack.getOutputDetails("disableAzureDnsCertManagement");
+    const disableAzureDnsCertManagement = getValue<boolean>(enableAzureDnsCertManagementValue, false);
 
     const azureDnsZoneValue = await clusterStack.getOutputDetails("azureDnsZone");
     const azureDnsZone = getValue<string>(azureDnsZoneValue, "");
@@ -43,7 +43,7 @@ export const getConfig = async () => {
     let apiTlsKey: Output<string> | undefined;
     let consoleTlsCert: Output<string> | undefined;
     let consoleTlsKey: Output<string> | undefined;
-    if (!enableAzureDnsCertManager) {
+    if (disableAzureDnsCertManagement) {
         apiTlsKey = stackConfig.requireSecret("apiTlsKey");
         apiTlsCert = stackConfig.requireSecret("apiTlsCert");
         consoleTlsKey = stackConfig.requireSecret("consoleTlsKey");
@@ -57,7 +57,7 @@ export const getConfig = async () => {
         kubeconfig: clusterStack.requireOutput("kubeconfig"),
         licenseKey: stackConfig.requireSecret("licenseKey"),
         database: {
-            connectionString: infrastructureStack.requireOutput("dbConnectionString"),
+            endpoint: infrastructureStack.requireOutput("dbEndpoint"),
             login: infrastructureStack.requireOutput("dbLogin"),
             password: infrastructureStack.requireOutput("dbPassword"),
             serverName: infrastructureStack.requireOutput("dbServerName")
@@ -95,7 +95,7 @@ export const getConfig = async () => {
         apiTlsCert,
         consoleTlsKey,
         consoleTlsCert,
-        enableAzureDnsCertManager,
+        disableAzureDnsCertManagement,
         azureDnsZone,
         azureDnsZoneResourceGroup,
         certManagerNamespace,

--- a/aks-hosted/03-application/index.ts
+++ b/aks-hosted/03-application/index.ts
@@ -47,7 +47,7 @@ export = async () => {
       consoleTlsCert: config.consoleTlsCert,
       consoleTlsKey: config.consoleTlsKey,
       database: {
-        connectionString: config.database.connectionString,
+        endpoint: config.database.endpoint,
         login: config.database.login,
         password: config.database.password,
         serverName: config.database.serverName
@@ -324,7 +324,7 @@ export = async () => {
   }
 
   const certSecretName = `${commonName}-tls`;
-  if (config.enableAzureDnsCertManager) {
+  if (!config.disableAzureDnsCertManagement) {
     const cert = new CertManagerDeployment(commonName, {
       provider,
       domains: [
@@ -360,11 +360,11 @@ export = async () => {
       tls: [
         {
           hosts: [config.consoleDomain],
-          secretName: config.enableAzureDnsCertManager ? certSecretName : secrets.ConsoleCertificateSecret?.metadata.name,
+          secretName: !config.disableAzureDnsCertManagement ? certSecretName : secrets.ConsoleCertificateSecret?.metadata.name,
         },
         {
           hosts: [config.apiDomain],
-          secretName: config.enableAzureDnsCertManager ? certSecretName : secrets.ApiCertificateSecret?.metadata.name,
+          secretName: config.disableAzureDnsCertManagement ? certSecretName : secrets.ApiCertificateSecret?.metadata.name,
         }
       ],
       rules: [

--- a/aks-hosted/03-application/secrets.ts
+++ b/aks-hosted/03-application/secrets.ts
@@ -14,7 +14,7 @@ export interface SecretsCollectionArgs {
         consoleTlsKey: Output<string> | undefined,
         consoleTlsCert: Output<string> | undefined,
         database: {
-            connectionString: Input<string>,
+            endpoint: Input<string>,
             login: Input<string>,
             password: Input<string>,
             serverName: Input<string>,
@@ -77,8 +77,8 @@ export class SecretsCollection extends ComponentResource {
                 namespace: args.namespace,
             },
             stringData: {
-                host: args.secretValues.database.connectionString,
-                username: interpolate`${args.secretValues.database.login}@${args.secretValues.database.serverName}`,
+                host: args.secretValues.database.endpoint,
+                username: args.secretValues.database.login, // interpolate`${args.secretValues.database.login}@${args.secretValues.database.serverName}`,
                 password: args.secretValues.database.password,
             },
         }, { provider: args.provider, parent: this });

--- a/aks-hosted/03-application/secrets.ts
+++ b/aks-hosted/03-application/secrets.ts
@@ -78,7 +78,7 @@ export class SecretsCollection extends ComponentResource {
             },
             stringData: {
                 host: args.secretValues.database.endpoint,
-                username: args.secretValues.database.login, // interpolate`${args.secretValues.database.login}@${args.secretValues.database.serverName}`,
+                username: args.secretValues.database.login,
                 password: args.secretValues.database.password,
             },
         }, { provider: args.provider, parent: this });

--- a/aks-hosted/03-application/sso-cert.ts
+++ b/aks-hosted/03-application/sso-cert.ts
@@ -23,7 +23,7 @@ export class SsoCertificate extends ComponentResource {
 
         const ssoCert = new SelfSignedCert(`ssoCert-${currentYear}`, {
             allowedUses: ["cert_signing"],
-            keyAlgorithm: "RSA",
+            //keyAlgorithm: "RSA",
             privateKeyPem: ssoPrivateKey.privateKeyPem,
             subject: {
                 commonName: `${args.apiDomain}`,

--- a/aks-hosted/README.md
+++ b/aks-hosted/README.md
@@ -60,9 +60,9 @@ To deploy entire stack, run the following in your terminal:
 1. `pulumi stack init {stackName1}` - see note above about NO NUMBERS in stack name
 1. `pulumi config set azure-native:location {azure region}`
 1. `pulumi config set networkCidr 10.2.0.0/16` - this should be set to what you want your VNet cidr block to be  
-1. **Note** if you elect to provide an existing Azure VirtualNetwork, instead of `networkCidr` you'll be required to provide the following:`pulumi config set virtualNetworkId /subscriptions/0282681f-7a9e-424b-80b2-96babd57a8a1/resourceGroups/someRG/providers/Microsoft.Network/virtualNetworks/some-vnet`
-1. `pulumi config set virtualNetworkResourceGroup someRG` (the resource groupname from the existing vnet)
+1. **Note** if you elect to provide an existing Azure VirtualNetwork, instead of `networkCidr` you'll be required to provide the following:`pulumi config set virtualNetworkName someVnet && pulumi config set virtualNetworkResourceGroup vnetResourceGroup`
 1. `pulumi config set subnetCidr 10.2.1.0/24` - this should be set to what you want your subnet cidr block to be
+1. `pulumi config set dbSubnetCidr 10.2.2.0/24` - this should be set to what you want your DB subnet cidr block to be
 1. `az login` (to avoid the following error: Could not create service principal: graphrbac.ServicePrincipalsClient#Create: Failure)
 1. `pulumi up`
 1. `cd ../02-kubernetes`
@@ -83,10 +83,6 @@ To deploy entire stack, run the following in your terminal:
 1. `pulumi config set licenseKey {licenseKey} --secret`
 1. `pulumi config set imageTag {imageTag}`
 1. `pulumi config set samlEnabled {true | false}` - If not configuring SAML SSO initially, skip or set to false.
-1. `cat {path to api key file} | pulumi config set apiTlsKey --secret --` (on a mac or linux machine)
-1. `cat {path to api cert file} | pulumi config set apiTlsCert --secret --` (on a mac or linux machine)
-1. `cat {path to console key file} | pulumi config set consoleTlsKey --secret --` (on a mac or linux machine)
-1. `cat {path to console cert file} | pulumi config set consoleTlsCert --secret --` (on a mac or linux machine)
 
 The following settings are optional.  
 Note if not set, "forgot password" and email invites will not work but sign ups and general functionality will still work.


### PR DESCRIPTION
This PR makes the following changes:
- 01-infrastructure now uses azure-nativev2 (currently beta). 
- 01-infrastructure creates MySQL Flexible Server rather than Single Server; SS is EOL 9/24.
- 01-infrastructure creates two subnets; one for AKS and one delegated subnet for MySQL
- 01-infrastructure creates a Private DNS Zone and records to allow MySQL DB to be completely private; only AKS subnet is allowed direct communication w/ DB.
- 02-kubernetes make AzureDnsCertManagement the default, but can be disabled