### PR TITLE
Allow self-hosted to operate in a private-only mode

### DIFF
--- a/aks-hosted/01-infrastructure/index.ts
+++ b/aks-hosted/01-infrastructure/index.ts
@@ -58,8 +58,9 @@ export = async () => {
 
     // our aks cluster will use this SP and it needs to be able to perform actions on subnets
     // to place nodes appropriately into our snets
+    // requires Network Contributor role: https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#network-contributor
     new authorization.RoleAssignment(`${config.resourceNamePrefix}-roleassign-snet`, {
-        roleDefinitionId: "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7",
+        roleDefinitionId: "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7", 
         scope: network.vnetId,
         principalId: adApplication.PrincipalServerObjectId,
         principalType: "ServicePrincipal",

--- a/aks-hosted/01-infrastructure/index.ts
+++ b/aks-hosted/01-infrastructure/index.ts
@@ -1,4 +1,4 @@
-import { resources } from "@pulumi/azure-native";
+import { authorization, resources } from "@pulumi/azure-native";
 import * as ad from "./activedirectory";
 import * as networking from "./network"
 import * as storage from "./storage";
@@ -8,13 +8,20 @@ import { config } from "./config";
 import { output } from "@pulumi/pulumi";
 
 export = async () => {
+
+    // retrieve informatino about our currently deployment user (principal)
+    const azureClientConfig = await authorization.getClientConfig();
+
     // although this RG may not house the vnet, it will house all the remaining resources we create
     const resourceGroup = new resources.ResourceGroup(`${config.resourceNamePrefix}-rg`, {
         resourceGroupName: config.disableAutoNaming ? `${config.resourceNamePrefix}-rg` : undefined,
         tags: config.baseTags,
     }, { protect: true });
 
-    const adApplication = new ad.ActiveDirectoryApplication(`${config.resourceNamePrefix}`);
+    const adApplication = new ad.ActiveDirectoryApplication(config.resourceNamePrefix, {
+        userId: azureClientConfig.objectId,
+    });
+
     const vnetResourceGroupName = config.vnetResourceGroup && config.vnetResourceGroup != "" ?
         output(config.vnetResourceGroup) :
         resourceGroup.name;
@@ -44,9 +51,18 @@ export = async () => {
 
     const kv = new key.KeyStorage(config.resourceNamePrefix, {
         objectId: adApplication.PrincipalServerObjectId,
-        tenantId: adApplication.TenantId,
+        tenantId: azureClientConfig.tenantId,
         resourceGroupName: resourceGroup.name,
         tags: config.baseTags,
+    });
+
+    // our aks cluster will use this SP and it needs to be able to perform actions on subnets
+    // to place nodes appropriately into our snets
+    new authorization.RoleAssignment(`${config.resourceNamePrefix}-roleassign-snet`, {
+        roleDefinitionId: "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7",
+        scope: network.vnetId,
+        principalId: adApplication.PrincipalServerObjectId,
+        principalType: "ServicePrincipal",
     });
 
     return {
@@ -54,8 +70,8 @@ export = async () => {
         adGroupId: adApplication.GroupId,
         adApplicationId: adApplication.ApplicationId,
         adApplicationSecret: adApplication.ApplicationSecret,
-        tenantId: adApplication.TenantId,
-        subscriptionId: adApplication.SubscriptionId,
+        tenantId: azureClientConfig.tenantId,
+        subscriptionId: azureClientConfig.subscriptionId,
         networkSubnetId: network.subnetId,
         storageAccountId: storageDetails.storageAccountId,
         storagePrimaryKey: storageDetails.storageAccountKey1,

--- a/aks-hosted/01-infrastructure/keyStorage.ts
+++ b/aks-hosted/01-infrastructure/keyStorage.ts
@@ -3,7 +3,7 @@ import { ComponentResource, ComponentResourceOptions, Input, Output, interpolate
 
 export interface KeyStorageArgs {
     objectId: Output<string>,
-    tenantId: Output<string>,
+    tenantId: string,
     resourceGroupName: Output<string>,
     tags?: Input<{
         [key: string]: Input<string>;

--- a/aks-hosted/02-kubernetes/config.ts
+++ b/aks-hosted/02-kubernetes/config.ts
@@ -18,8 +18,10 @@ let azureDnsZoneName = undefined;
 let azureDnsZoneResourceGroup = undefined;
 if (!disableAzureDnsCertManagement) {
     azureDnsZoneName = stackConfig.require("azureDnsZoneName");
-    azureDnsZoneResourceGroup = stackConfig.require("azureDnsZoneResourceGroup");
+    azureDnsZoneResourceGroup = stackConfig.require("azureDnsZoneResourceGroupName");
 }
+
+const privateIpAddress = stackConfig.get("privateIpAddress");
 
 export const config = {
     projectName,
@@ -28,13 +30,15 @@ export const config = {
     disableAzureDnsCertManagement,
     azureDnsZoneName,
     azureDnsZoneResourceGroup,
+    privateIpAddress,
+    enablePrivateLoadBalancer: privateIpAddress != undefined,
     baseTags: {
         project: projectName,
         stack: stackName,
     },
     resourceGroupName: <Output<string>>infrastructureStack.requireOutput("resourceGroupName"),
+    subnetId: <Output<string>>infrastructureStack.requireOutput("networkSubnetId"),
     adGroupId: <Output<string>>infrastructureStack.requireOutput("adGroupId"),
     adApplicationId: <Output<string>>infrastructureStack.requireOutput("adApplicationId"),
     adApplicationSecret: <Output<string>>infrastructureStack.requireOutput("adApplicationSecret"),
-    subnetId: <Output<string>>infrastructureStack.requireOutput("networkSubnetId"),
 };

--- a/aks-hosted/README.md
+++ b/aks-hosted/README.md
@@ -55,50 +55,58 @@ To ensure that the Pulumi program can access variables between the three deploym
 
 To deploy entire stack, run the following in your terminal:
 
-1. `cd 01-infrastructure`
-1. `npm install`
-1. `pulumi stack init {stackName1}` - see note above about NO NUMBERS in stack name
-1. `pulumi config set azure-native:location {azure region}`
-1. `pulumi config set networkCidr 10.2.0.0/16` - this should be set to what you want your VNet cidr block to be  
-1. **Note** if you elect to provide an existing Azure VirtualNetwork, instead of `networkCidr` you'll be required to provide the following:`pulumi config set virtualNetworkName someVnet && pulumi config set virtualNetworkResourceGroup vnetResourceGroup`
-1. `pulumi config set subnetCidr 10.2.1.0/24` - this should be set to what you want your subnet cidr block to be
-1. `pulumi config set dbSubnetCidr 10.2.2.0/24` - this should be set to what you want your DB subnet cidr block to be
-1. `az login` (to avoid the following error: Could not create service principal: graphrbac.ServicePrincipalsClient#Create: Failure)
-1. `pulumi up`
-1. `cd ../02-kubernetes`
-1. `npm install`
-1. `pulumi stack init {stackName2}` - see note above about NO NUMBERS in stack name
-1. `pulumi config set stackName1 {stackName1}` 
-1. **OPTIONAL** `pulumi config set enableAzureDnsCertManagement true` **NOTE** this requires both `azureDnsZoneName` and `azureDnsZoneResourceGroup` to be set
-1. **OPTIONAL** if `enableAzureDnsCertManagement` is set then: `pulumi config set azureDnsZoneName {zone_name}`
-1. **OPTIONAL** if `enableAzureDnsCertManagement` is set then: `pulumi config set azureDnsZoneResourceGroup {resource_group_name}`
-1. `pulumi up`
-1. `cd ../03-application`
-1. `npm install`
-1. `pulumi stack init {stackName3}` - see note above about NO NUMBERS in stack name
-1. `pulumi config set stackName1 {stackName1}`
-1. `pulumi config set stackName2 {stackName2}`
-1. `pulumi config set apiDomain {domain for api}`
-1. `pulumi config set consoleDomain {domain for console}`
-1. `pulumi config set licenseKey {licenseKey} --secret`
-1. `pulumi config set imageTag {imageTag}`
-1. `pulumi config set samlEnabled {true | false}` - If not configuring SAML SSO initially, skip or set to false.
+## 01-infrastructure
+- `cd 01-infrastructure`
+- `npm install`
+- `pulumi stack init {stackName1}` - see note above about NO NUMBERS in stack name
+- `pulumi config set azure-native:location {azure region}`
+- `pulumi config set networkCidr 10.2.0.0/16` - this should be set to what you want your VNet cidr block to be  
+- **Note** if you elect to provide an existing Azure VirtualNetwork, instead of `networkCidr` you'll be required to provide the following:`pulumi config set virtualNetworkName someVnet && pulumi config set virtualNetworkResourceGroup vnetResourceGroup`
+- `pulumi config set subnetCidr 10.2.1.0/24` - this should be set to what you want your subnet cidr block to be
+- `pulumi config set dbSubnetCidr 10.2.2.0/24` - this should be set to what you want your DB subnet cidr block to be
+- `az login` (to avoid the following error: Could not create service principal: graphrbac.ServicePrincipalsClient#Create: Failure)
+- `pulumi up`
+
+## 02-kubernetes
+- `cd ../02-kubernetes`
+- `npm install`
+- `pulumi config set azureDnsZoneName {DNS_ZONE_NAME}`
+- `pulumi config set azureDnsZoneResourceGroup {DNS_ZONE_RESOURCE_GROUP_NAME}`
+- `pulumi stack init {stackName2}` - see note above about NO NUMBERS in stack name
+- `pulumi config set stackName1 {stackName1}` 
+  
+The following settings are optional. 
+- `pulumi config set disableAzureDnsCertManagement true` **NOTE** this disables the cert-manager deployment which hanldes SSL certificates. 03-application will need TLS certificates.
+- `pulumi config set privateIpAddress {private_ip_from_vnet}` - this will disable the ingress services public IP address and deploy an internal load balancer. This blocks all public access to the Pulumi self-hosted app.
+
+## 03-application
+- `pulumi up`
+- `cd ../03-application`
+- `npm install`
+- `pulumi stack init {stackName3}` - see note above about NO NUMBERS in stack name
+- `pulumi config set stackName1 {stackName1}`
+- `pulumi config set stackName2 {stackName2}`
+- `pulumi config set apiDomain {domain for api}`
+- `pulumi config set consoleDomain {domain for console}`
+- `pulumi config set licenseKey {licenseKey} --secret`
+- `pulumi config set imageTag {imageTag}`
+- `pulumi config set samlEnabled {true | false}` - If not configuring SAML SSO initially, skip or set to false.
 
 The following settings are optional.  
 Note if not set, "forgot password" and email invites will not work but sign ups and general functionality will still work.
-1. `cat {path to api key file} | pulumi config set apiTlsKey --secret --` (on a mac or linux machine) **NOT REQUIRED IF CERT-MANAGER IS ENABLED**
-1. `cat {path to api cert file} | pulumi config set apiTlsCert --secret --` (on a mac or linux machine) **NOT REQUIRED IF CERT-MANAGER IS ENABLED**
-1. `cat {path to console key file} | pulumi config set consoleTlsKey --secret --` (on a mac or linux machine) **NOT REQUIRED IF CERT-MANAGER IS ENABLED**
-1. `cat {path to console cert file} | pulumi config set consoleTlsCert --secret --` (on a mac or linux machine) **NOT REQUIRED IF CERT-MANAGER IS ENABLED**
-1. `pulumi config set smtpServer {smtp server:port}` (for example: smtp.domain.com:587)
-1. `pulumi config set smtpUsername {smtp username}`
-1. `pulumi config set smtpPassword {smtp password} --secret`
-1. `pulumi config set smtpFromAddress {smtp from address}` (email address that the outgoing emails come from)
-1. `pulumi config set recaptchaSiteKey {recaptchaSiteKey}` (this must be a v2 type recaptcha)
-1. `pulumi config set recaptchaSecretKey {recaptchaSecretKey} --secret`
-1. `pulumi config set ingressAllowList {cidr range list}` (allow list of IPv4 CIDR ranges to allow access to the self-hosted Pulumi Cloud. Not setting this will allow the set up to be open to the internet). Proper formatting can be seen [here](https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#whitelist-source-range) 
-1. `pulumi config set certManagerEmail {email}` (email address that will be used for certificate expirations purposes from letsencrypt)
-1. `pulumi up`
+- `cat {path to api key file} | pulumi config set apiTlsKey --secret --` (on a mac or linux machine) **NOT REQUIRED IF CERT-MANAGER IS ENABLED**
+- `cat {path to api cert file} | pulumi config set apiTlsCert --secret --` (on a mac or linux machine) **NOT REQUIRED IF CERT-MANAGER IS ENABLED**
+- `cat {path to console key file} | pulumi config set consoleTlsKey --secret --` (on a mac or linux machine) **NOT REQUIRED IF CERT-MANAGER IS ENABLED**
+- `cat {path to console cert file} | pulumi config set consoleTlsCert --secret --` (on a mac or linux machine) **NOT REQUIRED IF CERT-MANAGER IS ENABLED**
+- `pulumi config set smtpServer {smtp server:port}` (for example: smtp.domain.com:587)
+- `pulumi config set smtpUsername {smtp username}`
+- `pulumi config set smtpPassword {smtp password} --secret`
+- `pulumi config set smtpFromAddress {smtp from address}` (email address that the outgoing emails come from)
+- `pulumi config set recaptchaSiteKey {recaptchaSiteKey}` (this must be a v2 type recaptcha)
+- `pulumi config set recaptchaSecretKey {recaptchaSecretKey} --secret`
+- `pulumi config set ingressAllowList {cidr range list}` (allow list of IPv4 CIDR ranges to allow access to the self-hosted Pulumi Cloud. Not setting this will allow the set up to be open to the internet). Proper formatting can be seen [here](https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#whitelist-source-range) 
+- `pulumi config set certManagerEmail {email}` (email address that will be used for certificate expirations purposes from letsencrypt)
+- `pulumi up`
 
 ### Configure DNS
 

--- a/aks-hosted/README.md
+++ b/aks-hosted/README.md
@@ -113,7 +113,7 @@ Note if not set, "forgot password" and email invites will not work but sign ups 
 To get the IP address output for the cluster, run the following in the `02-kubernetes` folder: 
 
 ```
-pulumi stack output ingressServiceIp
+pulumi stack output ingressIp
 ```
 
 Create DNS A record entries for `{domain for api}` and `{domain for console}` that point to the IP returned from the above command.


### PR DESCRIPTION
Changes within allow the self-hosted service to operate in a private network only mode. This is accomplished by:
- remove public IP from ingress
- supply a private IP address from vnet to ingress
- include an annotation on the ingress to create an internal load balancer, rather than a public one.