### PR TITLE
EKS README cleanup

### DIFF
--- a/eks-hosted/README.md
+++ b/eks-hosted/README.md
@@ -196,7 +196,8 @@ See the [pulumi login][pulumi-login-docs] docs for more details.
 ### Required Configuration
 
 > Note: All configuration properties shown in this section are **required**.
-
+> Note: If using the Pulumi backend to deploy, you may need to prepend each stack name with your org name, e.g.
+> <orgName>/my-selfhosted-01-cluster
 The installer requires a YAML configuration file with the following configuration properties:
 
 ```yaml

--- a/eks-hosted/README.md
+++ b/eks-hosted/README.md
@@ -223,7 +223,6 @@ Configuration properties can be passed for SMTP and SSO support as well as to th
 
 ```yaml
 region: us-west-2
-stackName: selfhosted-us-west-2
 licenseFilePath: pulumi-selfhosted-company.license
 route53Zone: example.com
 route53Subdomain: pulumi

--- a/eks-hosted/README.md
+++ b/eks-hosted/README.md
@@ -196,8 +196,9 @@ See the [pulumi login][pulumi-login-docs] docs for more details.
 ### Required Configuration
 
 > Note: All configuration properties shown in this section are **required**.
+
 > Note: If using the Pulumi backend to deploy, you may need to prepend each stack name with your org name, e.g.
-> <orgName>/my-selfhosted-01-cluster
+> MyOrganization/my-selfhosted-01-cluster
 The installer requires a YAML configuration file with the following configuration properties:
 
 ```yaml


### PR DESCRIPTION
Small tweak to EKS self-hosted deploy README.

@aureq:
> To be confirmed, but the stackName (see below) when connected to the Pulumi backend should include the <orgName> as shown below

This is true, but not necessarily in all cases, and would also affect all of the example config files we've included in `eks-hosted`--so I opted to go with a note here as the less intrusive change.

> The following elements are probably not optional anymore ...

I think you are referring to [these](https://github.com/pulumi/pulumi-self-hosted-installers/blob/devon/eks-readme-cleanup/eks-hosted/README.md?plain=1#L261-L280)? I opted to leave them in because it looks like we have included some other required parameters in this snippet so that the config is fully qualified. Let me know if I misunderstood.

## Related issues
Fixes #58