### PR TITLE
Remove opensearch from docker-compose installer

### DIFF
--- a/quickstart-docker-compose/docker-compose.yml
+++ b/quickstart-docker-compose/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       AZURE_TENANT_ID:
       AZURE_SUBSCRIPTION_ID:
       # Search env vars
-      PULUMI_SEARCH_DOMAIN:
+      PULUMI_SEARCH_DOMAIN: "${PULUMI_SEARCH_DOMAIN}"
       PULUMI_SEARCH_USER:
       PULUMI_SEARCH_PASSWORD:
     networks:

--- a/quickstart-docker-compose/docker-compose.yml
+++ b/quickstart-docker-compose/docker-compose.yml
@@ -10,52 +10,6 @@ networks:
 
 services:
 
-  opensearch:
-    image: opensearchproject/opensearch:2.11.1
-    container_name: search
-    ulimits:
-      memlock:
-        soft: -1 # Set memlock to unlimited (no soft or hard limit)
-        hard: -1
-      nofile:
-        soft: 65536 # Maximum number of open files for the opensearch user - set to at least 65536
-        hard: 65536
-    volumes:
-      - $PULUMI_DATA_PATH/opensearch/data:$PULUMI_DATA_PATH/opensearch/data
-    ports:
-      - "9200:9200"
-      - "9300:9300"
-      - "9600:9600"
-    expose:
-      - 9200
-      - 9300
-      - 9600
-    env_file: ../search_vars.env
-    networks:
-      - pulumi-services
-    healthcheck:
-      test: ["CMD-SHELL", "curl -u admin:admin -f http://localhost:9200 || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
-      start_period: 10s
-    restart: unless-stopped
-
-  opensearch-dashboards:
-    image: opensearchproject/opensearch-dashboards:2.11.1
-    container_name: opensearch-dashboards
-    ports:
-      - "5601:5601"
-    expose:
-      - 5601
-    environment:
-      OPENSEARCH_HOSTS: '["http://search:9200"]'
-    networks:
-      - pulumi-services
-    depends_on:
-      opensearch:
-        condition: service_healthy
-
   api:
     ports:
       - "8080:8080"
@@ -133,9 +87,6 @@ services:
       nofile:
         soft: 100000
         hard: 200000
-    depends_on:
-      opensearch:
-        condition: service_healthy
     restart: unless-stopped
 
   console:

--- a/quickstart-docker-compose/scripts/run-ee.sh
+++ b/quickstart-docker-compose/scripts/run-ee.sh
@@ -65,6 +65,24 @@ fi
 
 export PULUMI_DATABASE_ENDPOINT="${PULUMI_LOCAL_DATABASE_HOST}:${PULUMI_LOCAL_DATABASE_PORT}"
 
+if [ -z "${PULUMI_SEARCH_HOST:-}" ]; then
+    PULUMI_SEARCH_HOST="http://opensearch"
+fi
+
+if [ -z "${PULUMI_SEARCH_PORT:-}" ]; then
+    PULUMI_SEARCH_PORT=9200
+fi
+
+export PULUMI_SEARCH_DOMAIN="${PULUMI_SEARCH_HOST}:${PULUMI_SEARCH_PORT}"
+
+if [ -z "${PULUMI_SEARCH_USER:-}" ]; then
+    export PULUMI_SEARCH_USER=admin
+fi
+
+if [ -z "${PULUMI_SEARCH_PASSWORD:-}" ]; then
+    export PULUMI_SEARCH_PASSWORD=admin
+fi
+
 if [[ -z "${PULUMI_LOCAL_OBJECTS:-}" ]] && [[ -z "${PULUMI_CHECKPOINT_BLOB_STORAGE_ENDPOINT:-}" ]]; then
     echo "Checkpoint object storage configuration not found. Defaulting to local path..."
     export PULUMI_LOCAL_OBJECTS="${PULUMI_DATA_PATH}/checkpoints"


### PR DESCRIPTION
Search is included in the all-in-one installer, but not the basic docker-compose installer, which expects the user to have a separate OpenSearch cluster.