### PR TITLE
Add support for metadata lock options

### DIFF
--- a/quickstart-docker-compose/scripts/migrate-db.sh
+++ b/quickstart-docker-compose/scripts/migrate-db.sh
@@ -58,7 +58,7 @@ if [ ! -z "${DATABASE_CA_CERTIFICATE:-}" ]; then
 fi
 
 # If METADATA_LOCK_WAIT_TIMEOUT is set, then enable the special extensions we've added to our fork of
-# pulumi/golang-migrate to support timing out if metadata locks are held for too long waiting too start
+# pulumi/golang-migrate to support timing out if metadata locks are held for too long waiting to start
 # the migration.
 if [ -z "${METADATA_LOCK_WAIT_TIMEOUT:-}" ]; then
     DB_QUERY_STRING="${DB_QUERY_STRING}&x-metadata-lock-timeout=${METADATA_LOCK_WAIT_TIMEOUT}&x-metadata-lock-retries=${METADATA_LOCK_RETRIES:-20}"

--- a/quickstart-docker-compose/scripts/migrate-db.sh
+++ b/quickstart-docker-compose/scripts/migrate-db.sh
@@ -25,19 +25,7 @@ which migratecli >/dev/null || {
     # https://github.com/golang-migrate/migrate/blob/master/CONTRIBUTING.md
     INSTALL_DEST=${GOBIN:-$(go env GOPATH)/bin}
 
-    # If GOOS (read Go OS) is not set, then try and determine if this is a linux-like environment.
-    if [ -z "${GOOS:-}" ]; then
-        case $(uname) in
-            "Linux") GOOS="linux";;
-            "Darwin") GOOS="darwin";;
-            *)
-                echo "Unknown OS"
-                exit 1
-                ;;
-        esac
-    fi
-
-    GOOS="${GOOS}" DATABASE=mysql SOURCE=file CLI_BUILD_OUTPUT=${INSTALL_DEST}/migratecli make build-cli
+    DATABASE=mysql SOURCE=file CLI_BUILD_OUTPUT=${INSTALL_DEST}/migratecli make build-cli
     popd
 
     # Ensure the version we built is on the PATH for the rest of this script


### PR DESCRIPTION
This adds extra arguments for a forth-coming extension to our golang-migrate fork.

Also, remove GOOS detection. `go build` is perfectly capable of handling that on its own.

The new options won't take effect until https://github.com/pulumi/golang-migrate/pull/13 is deployed.