### PR TITLE
update example stack config for 25-insights

### DIFF
--- a/eks-hosted/25-insights/Pulumi.README.yaml
+++ b/eks-hosted/25-insights/Pulumi.README.yaml
@@ -8,8 +8,5 @@ config:
   baseName: pulumiselfhost
 
   # Opensearch configuration
-  # Note: the domain name is derived from the baseName. See config.ts
-  openSearchInstanceType: t3.medium.search
-  openSearchInstanceCount: 3
-  openSearchDedicatedMasterCount: 0
-  
+  # Use "pulumi config set opensearchPassword --secret <password>"
+  opensearchPassword: 


### PR DESCRIPTION
The `pulumi.README.yaml` still had AWS opensearch config items listed.
Those were removed.
Also added the password item.