### PR TITLE
add comments for how to use local copy of opensearch chart and clean up some code for the DB.

### DIFF
--- a/components-microstacks/openSearch.ts
+++ b/components-microstacks/openSearch.ts
@@ -3,6 +3,11 @@ import * as k8s from "@pulumi/kubernetes";
 import { Input, Output, ComponentResource, ComponentResourceOptions } from "@pulumi/pulumi";
 import { CustomResource } from "@pulumi/kubernetes/apiextensions"
 
+// NOTE: If you need to use a local version of the helm charts instead of the remote repo, do the following:
+// - Locally copy the repo: `git clone https://github.com/opensearch-project/helm-charts.git`
+// - Comment out the fetchOpts and repo fields in the two helm charts resources below.
+// - Uncomment the path field for each helm chart resources and set it to the local path of the opensearch or opensearch-dashboard helm chart accordingly.   
+
 export interface OpenSearchArgs {
     namespace: Output<string>,
     serviceAccount: Input<string>,
@@ -25,9 +30,12 @@ export class OpenSearch extends ComponentResource {
             chart: osChartName,
             version: chartVersion,
             namespace: args.namespace,
+            // Comment out the fetchOpts block if using local copy of the helm chart.
+            // And uncomment the path field and set it to the local path of the helm chart if using a local copy of the helm chart.
             fetchOpts: {
                 repo: osRepoUrl,
             },
+            // path: "/path/to/local/helm-charts/charts",
             values: {
                 roles: [
                     "master",
@@ -75,9 +83,12 @@ export class OpenSearch extends ComponentResource {
             chart: `${osChartName}-dashboards`,
             version: "2.22.0",
             namespace: args.namespace,
+            // Comment out the fetchOpts block if using local copy of the helm chart.
+            // And, uncomment the path field and set it to the local path of the helm chart if using a local copy of the helm chart.
             fetchOpts: {
                 repo: osRepoUrl,
             },
+            // path: "/path/to/local/helm-charts/charts",
             values: {
                 replicas: 1,
                 imageTag: oscVersion,

--- a/eks-hosted/20-database/rds-db/index.ts
+++ b/eks-hosted/20-database/rds-db/index.ts
@@ -59,7 +59,8 @@ export class RdsDatabase extends pulumi.ComponentResource {
             masterUsername: "pulumi",
             masterPassword: this.password,
             storageEncrypted: true,
-            vpcSecurityGroupIds: [args.securityGroupId],         // Must be able to communicate with EKS nodes.
+            // vpcSecurityGroupIds: [args.securityGroupId],         // Must be able to communicate with EKS nodes.
+            vpcSecurityGroupIds: pulumi.output(args.securityGroupId).apply(id => [id]),        // Must be able to communicate with EKS nodes.
             finalSnapshotIdentifier: finalSnapshotIdentifier.hex,
             tags,
         }, { protect: true, });

--- a/eks-hosted/20-database/rds-db/index.ts
+++ b/eks-hosted/20-database/rds-db/index.ts
@@ -59,7 +59,6 @@ export class RdsDatabase extends pulumi.ComponentResource {
             masterUsername: "pulumi",
             masterPassword: this.password,
             storageEncrypted: true,
-            // vpcSecurityGroupIds: [args.securityGroupId],         // Must be able to communicate with EKS nodes.
             vpcSecurityGroupIds: pulumi.output(args.securityGroupId).apply(id => [id]),        // Must be able to communicate with EKS nodes.
             finalSnapshotIdentifier: finalSnapshotIdentifier.hex,
             tags,

--- a/eks-hosted/25-insights/index.ts
+++ b/eks-hosted/25-insights/index.ts
@@ -1,7 +1,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as k8s from "@pulumi/kubernetes";
-// import { OpenSearchArgs, OpenSearch } from "../../components-microstacks/openSearch";
-import { OpenSearchArgs, OpenSearch } from "../../../insights-local-test/openSearch";
+import { OpenSearchArgs, OpenSearch } from "../../components-microstacks/openSearch";
 import { config } from "./config";
 
 const baseName = config.baseName 

--- a/eks-hosted/25-insights/index.ts
+++ b/eks-hosted/25-insights/index.ts
@@ -1,6 +1,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as k8s from "@pulumi/kubernetes";
-import { OpenSearchArgs, OpenSearch } from "../../components-microstacks/openSearch";
+// import { OpenSearchArgs, OpenSearch } from "../../components-microstacks/openSearch";
+import { OpenSearchArgs, OpenSearch } from "../../../insights-local-test/openSearch";
 import { config } from "./config";
 
 const baseName = config.baseName 


### PR DESCRIPTION
Added some comments to the OpenSearch component resource for customers who need to use local versions of the opensearch charts.
Also, addressed a minor typing error for the RDS component resource. 