### PR TITLE
Wait for migrations to finish in docker compose

### DIFF
--- a/quickstart-docker-compose/all-in-one/docker-compose.yml
+++ b/quickstart-docker-compose/all-in-one/docker-compose.yml
@@ -135,6 +135,8 @@ services:
         condition: service_healthy
       db:
         condition: service_started
+      migration:
+        condition: service_completed_successfully
     restart: unless-stopped
 
   console:


### PR DESCRIPTION
The API container was not waiting for the DB migrations to finish, which can leave the service in an inconsistent state on startup.