### PR TITLE
Make SSH key available to service build

### DIFF
--- a/quickstart-docker-compose/all-in-one/docker-compose.override.yml
+++ b/quickstart-docker-compose/all-in-one/docker-compose.override.yml
@@ -19,6 +19,9 @@ services:
     build:
       context: ../../../
       dockerfile: ./cmd/service/Dockerfile
+      target: service
+      ssh:
+        - default
 
   console:
     ports:

--- a/quickstart-docker-compose/docker-compose.override.yml
+++ b/quickstart-docker-compose/docker-compose.override.yml
@@ -22,6 +22,9 @@ services:
     build:
       context: ../../
       dockerfile: ./cmd/service/Dockerfile
+      target: service
+      ssh:
+        - default
     environment:
       API_TLS_CERTIFICATE: "${API_TLS_CERTIFICATE}"
       API_TLS_PRIVATE_KEY: "${API_TLS_PRIVATE_KEY}"

--- a/quickstart-docker-compose/scripts/run-ee.sh
+++ b/quickstart-docker-compose/scripts/run-ee.sh
@@ -104,9 +104,9 @@ docker_compose_stop() {
 trap docker_compose_stop SIGINT SIGTERM ERR EXIT
 
 if [ -z "${DOCKER_COMPOSE_ARGS:-}" ]; then
-    docker compose up --build
+    DOCKER_BUILDKIT=1 docker compose up --build
 else
     # Don't add quotes around the variable below. We might pass multiple args and the quotes
     # will make multiple args look like a single arg.
-    docker compose ${DOCKER_COMPOSE_ARGS} up --build
+    DOCKER_BUILDKIT=1 docker compose ${DOCKER_COMPOSE_ARGS} up --build
 fi


### PR DESCRIPTION
The service image build process has changed, and needs to mount the default SSH key into the container during the build. This does not affect consumers of the service image, but we use the Docker compose installer during internal testing, so the build option needs to be added.