### PR TITLE
Add build context for Pulumi design system

### DIFF
--- a/quickstart-docker-compose/docker-compose.override.yml
+++ b/quickstart-docker-compose/docker-compose.override.yml
@@ -39,7 +39,9 @@ services:
       - "3443:3443"
     image: "pulumi/console:scratch"
     build:
-      context: "../../cmd/console2 --build-context pulumi-design-system=../../cmd/pulumi-design-system"
+      context: ../../cmd/console2
+      additional_contexts:
+        - pulumi-design-system=../../cmd/pulumi-design-system
       args:
         - SKIP_PULUMI_CONSOLE_DOCKER_BUILD
     environment:

--- a/quickstart-docker-compose/docker-compose.override.yml
+++ b/quickstart-docker-compose/docker-compose.override.yml
@@ -39,7 +39,7 @@ services:
       - "3443:3443"
     image: "pulumi/console:scratch"
     build:
-      context: ../../cmd/console2
+      context: "../../cmd/console2 --build-context pulumi-design-system=../../cmd/pulumi-design-system"
       args:
         - SKIP_PULUMI_CONSOLE_DOCKER_BUILD
     environment:


### PR DESCRIPTION
In [this PR on the service side](https://github.com/pulumi/pulumi-service/pull/24508), we are adding our Pulumi Design System component library for use in the service.  PDS needs to be pulled into the docker build.  [Here is a test run on the service side](https://github.com/pulumi/pulumi-service/pull/24615) that shows successful tests when pointed to this change.