### PR TITLE
Back-compat support for mysqladmin command

### DIFF
--- a/quickstart-docker-compose/scripts/init-db-container.sh
+++ b/quickstart-docker-compose/scripts/init-db-container.sh
@@ -33,7 +33,21 @@ if [ -z "${PULUMI_DATABASE_PING_ENDPOINT:-}" ]; then
     fi
 fi
 
-while ! mariadb-admin ping -h "${PULUMI_DATABASE_PING_ENDPOINT}" -P "${MYSQL_PORT}" --user="${MYSQL_ROOT_USERNAME}" --password="${MYSQL_ROOT_PASSWORD}" --skip-ssl --silent; do sleep 1; done
+# mysqladmin has been renamed to mariadb-admin and the old name produces deprecation warnings on newer releases.
+# Use mariadb-admin if present
+if command -v mariadb-admin >/dev/null 2>&1; then
+    DB_ADMIN_BINARY="mariadb-admin"
+# Fall back to using mysqladmin
+elif command -v mysqladmin >/dev/null 2>&1; then
+    DB_ADMIN_BINARY="mysqladmin"
+else
+    echo "Neither mariadb-admin nor mysqladmin is available in the PATH."
+    exit 1
+fi
+echo "Using: $DB_ADMIN_BINARY"
+
+# Check if the DB is ready.
+while ! ${DB_ADMIN_BINARY} ping -h "${PULUMI_DATABASE_PING_ENDPOINT}" -P "${MYSQL_PORT}" --user="${MYSQL_ROOT_USERNAME}" --password="${MYSQL_ROOT_PASSWORD}" --skip-ssl --silent; do sleep 1; done
 
 echo "MySQL is running!"
 


### PR DESCRIPTION
Handle both `mariadb-admin` and `mysqladmin` commands to support older releases that don't include `mariadb-admin`.