### PR TITLE
Fix DATA_PATH permissions for limited users

### DIFF
--- a/quickstart-docker-compose/scripts/run-ee.sh
+++ b/quickstart-docker-compose/scripts/run-ee.sh
@@ -38,6 +38,7 @@ fi
 
 if [ ! -d "$PULUMI_DATA_PATH" ]; then
     mkdir -p "${PULUMI_DATA_PATH}"
+    chmod 777 "${PULUMI_DATA_PATH}"
 fi
 
 export PULUMI_LOCAL_KEYS=${PULUMI_DATA_PATH}/localkeys


### PR DESCRIPTION
Make sure that the `pulumi` user can still write here after we stop running as root in the container.