### PR TITLE
Use /usr/bin/env bash in scripts instead of /bin/bash

### DIFF
--- a/quickstart-docker-compose/scripts/init-db-container.sh
+++ b/quickstart-docker-compose/scripts/init-db-container.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script update a DB instance running inside a
 # container by running the DB migrations against it.

--- a/quickstart-docker-compose/scripts/migrate-db.sh
+++ b/quickstart-docker-compose/scripts/migrate-db.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Bring the DB instance up-to-date with all current migrations.
 # Migrations will be executed as the password-less pulumi_service DB user unless

--- a/quickstart-docker-compose/scripts/run-db-container.sh
+++ b/quickstart-docker-compose/scripts/run-db-container.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script sets up a docker bridge network called pulumi-self-hosted-installers,
 # then starts a MySQL v5.7 container in that network.

--- a/quickstart-docker-compose/scripts/run-ee.sh
+++ b/quickstart-docker-compose/scripts/run-ee.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script is the main starting point for the quickstart solutions for self-hosted Pulumi Service.
 # By default, this script will use the docker-compose.yml file (and an override file, if present) in the root
 # directory of pulumi-self-hosted-installers.


### PR DESCRIPTION
`#!/bin/bash` does not work on systems for which `/bin/bash` is not a valid path. `/usr/bin/env` instead looks for `bash` within `PATH` for the current environment, which makes scripts more portable.