### PR TITLE
fix: migrate BYO installer from archived kubernetesx to kubernetes

### DIFF
--- a/byo-infra/02-kubernetes/helm-nginx-ingress.ts
+++ b/byo-infra/02-kubernetes/helm-nginx-ingress.ts
@@ -28,6 +28,9 @@ export class NginxIngress extends pulumi.ComponentResource {
             values: {
                 controller: {
                     replicaCount: 1,
+                    service: {
+                        type: "NodePort"
+                    },
                     // nodeSelector: {
                     //     "beta.kubernetes.io/os": "linux"
                     // },
@@ -49,8 +52,8 @@ export class NginxIngress extends pulumi.ComponentResource {
 
         this.IngressNamespace = ingressNamespace.metadata.name;
         this.IngressServiceIp = nginxIngress
-            .getResourceProperty("v1/Service", `${name}-ingress/${name}-ingress-ingress-nginx-controller`, "status")
-            .apply(status => status.loadBalancer.ingress[0].ip);
+            .getResourceProperty("v1/Service", `${name}-ingress/${name}-ingress-ingress-nginx-controller`, "spec")
+            .apply(spec => spec.clusterIP);
     
         this.registerOutputs({
             IngressNamespace: this.IngressNamespace,

--- a/byo-infra/03-application/config.ts
+++ b/byo-infra/03-application/config.ts
@@ -2,7 +2,7 @@ import * as pulumi from "@pulumi/pulumi";
 
 const stackConfig = new pulumi.Config();
 
-const commonName = "pulumi-selfhosted" || stackConfig.get("commonName");
+const commonName = stackConfig.get("commonName") || "pulumi-selfhosted";
 const projectName = pulumi.getProject();
 const stackName = pulumi.getStack();
 

--- a/byo-infra/03-application/encryption-service.ts
+++ b/byo-infra/03-application/encryption-service.ts
@@ -1,6 +1,5 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as k8s from "@pulumi/kubernetes";
-import * as kx from "@pulumi/kubernetesx";
 import * as random from "@pulumi/random";
 import { Input, Output, ComponentResource, ComponentResourceOptions } from "@pulumi/pulumi";
 import { secret } from "@pulumi/pulumi";
@@ -35,7 +34,7 @@ export class EncryptionService extends ComponentResource {
         }).result;
 
         // Store the string as a secret.
-        const pulumiLocalKeysSecret = new kx.Secret(`${args.commonName}-local-keys`, {
+        const pulumiLocalKeysSecret = new k8s.core.v1.Secret(`${args.commonName}-local-keys`, {
             metadata: { 
                 namespace: args.namespace, 
                 name: secretName 

--- a/byo-infra/03-application/index.ts
+++ b/byo-infra/03-application/index.ts
@@ -4,6 +4,7 @@ import {config} from "./config";
 import {SecretsCollection} from "./secrets";
 import {SsoCertificate} from "./sso-cert";
 import {EncryptionService} from "./encryption-service";
+import {createEnvValueFromSecret} from "./secret-utils";
 
 /**
  * Check pre-requisites.
@@ -64,8 +65,8 @@ const secrets = new SecretsCollection(`${commonName}-secrets`, {
       smtpFromAddress: config.smtpFromAddress,
     },
     recaptcha: {
-      secretKey: config.recaptchaSecretKey,
-      siteKey: config.recaptchaSiteKey
+      secretKey: config.recaptchaSecretKey || "",
+      siteKey: config.recaptchaSiteKey || ""
     }
   }
 });
@@ -100,19 +101,19 @@ const apiDeployment = new k8s.apps.v1.Deployment(`${commonName}-${apiName}`, {
               env: [
                   {
                       name: "PULUMI_DATABASE_ENDPOINT",
-                      valueFrom: secrets.DBConnSecret.asEnvValue("connectionString"),
+                      valueFrom: createEnvValueFromSecret(secrets.DBConnSecret, "connectionString"),
                   },
                   {
                       name: "MYSQL_ROOT_USERNAME",
-                      valueFrom: secrets.DBConnSecret.asEnvValue("username"),
+                      valueFrom: createEnvValueFromSecret(secrets.DBConnSecret, "username"),
                   },
                   {
                       name: "MYSQL_ROOT_PASSWORD",
-                      valueFrom: secrets.DBConnSecret.asEnvValue("password"),
+                      valueFrom: createEnvValueFromSecret(secrets.DBConnSecret, "password"),
                   },
                   {
                       name: "PULUMI_DATABASE_PING_ENDPOINT",
-                      valueFrom: secrets.DBConnSecret.asEnvValue("host"),
+                      valueFrom: createEnvValueFromSecret(secrets.DBConnSecret, "host"),
                   },
                   {
                       name: "RUN_MIGRATIONS_EXTERNALLY",
@@ -136,7 +137,7 @@ const apiDeployment = new k8s.apps.v1.Deployment(`${commonName}-${apiName}`, {
                 pulumiLocalKeySecret.encryptionServiceEnv,
                 {
                   name: "PULUMI_LICENSE_KEY",
-                  valueFrom: secrets.LicenseKeySecret.asEnvValue("key"),
+                  valueFrom: createEnvValueFromSecret(secrets.LicenseKeySecret, "key"),
                 },
                 {
                   name: "PULUMI_ENTERPRISE",
@@ -152,15 +153,15 @@ const apiDeployment = new k8s.apps.v1.Deployment(`${commonName}-${apiName}`, {
                 },
                 {
                   name: "PULUMI_DATABASE_ENDPOINT",
-                  valueFrom: secrets.DBConnSecret.asEnvValue("connectionString"),
+                  valueFrom: createEnvValueFromSecret(secrets.DBConnSecret, "connectionString"),
                 },
                 {
                   name: "PULUMI_DATABASE_USER_NAME",
-                  valueFrom: secrets.DBConnSecret.asEnvValue("username"),
+                  valueFrom: createEnvValueFromSecret(secrets.DBConnSecret, "username"),
                 },
                 {
                   name: "PULUMI_DATABASE_USER_PASSWORD",
-                  valueFrom: secrets.DBConnSecret.asEnvValue("password"),
+                  valueFrom: createEnvValueFromSecret(secrets.DBConnSecret, "password"),
                 },
                 {
                   name: "PULUMI_DATABASE_NAME",
@@ -168,11 +169,11 @@ const apiDeployment = new k8s.apps.v1.Deployment(`${commonName}-${apiName}`, {
                 },
                 {
                   name: "SAML_CERTIFICATE_PUBLIC_KEY",
-                  valueFrom: ssoSecret.SamlSsoSecret.asEnvValue("pubkey")
+                  valueFrom: createEnvValueFromSecret(ssoSecret.SamlSsoSecret, "pubkey")
                 },
                 {
                   name: "SAML_CERTIFICATE_PRIVATE_KEY",
-                  valueFrom: ssoSecret.SamlSsoSecret.asEnvValue("privatekey")
+                  valueFrom: createEnvValueFromSecret(ssoSecret.SamlSsoSecret, "privatekey")
                 },
                 {
                   name: "AWS_REGION",
@@ -180,11 +181,11 @@ const apiDeployment = new k8s.apps.v1.Deployment(`${commonName}-${apiName}`, {
                 },
                 {
                   name: "AWS_ACCESS_KEY_ID",
-                  valueFrom: secrets.StorageSecret.asEnvValue("accessKeyId")
+                  valueFrom: createEnvValueFromSecret(secrets.StorageSecret, "accessKeyId")
                 },
                 {
                   name: "AWS_SECRET_ACCESS_KEY",
-                  valueFrom: secrets.StorageSecret.asEnvValue("secretAccessKey")
+                  valueFrom: createEnvValueFromSecret(secrets.StorageSecret, "secretAccessKey")
                 },
                 {
                   name: "PULUMI_POLICY_PACK_BLOB_STORAGE_ENDPOINT",
@@ -196,23 +197,23 @@ const apiDeployment = new k8s.apps.v1.Deployment(`${commonName}-${apiName}`, {
                 },
                 {
                   name: "SMTP_SERVER",
-                  valueFrom: secrets.SmtpSecret.asEnvValue("server"),
+                  valueFrom: createEnvValueFromSecret(secrets.SmtpSecret, "server"),
                 },
                 {
                   name: "SMTP_USERNAME",
-                  valueFrom: secrets.SmtpSecret.asEnvValue("username"),
+                  valueFrom: createEnvValueFromSecret(secrets.SmtpSecret, "username"),
                 },
                 {
                   name: "SMTP_PASSWORD",
-                  valueFrom: secrets.SmtpSecret.asEnvValue("password"),
+                  valueFrom: createEnvValueFromSecret(secrets.SmtpSecret, "password"),
                 },
                 {
                   name: "SMTP_GENERIC_SENDER",
-                  valueFrom: secrets.SmtpSecret.asEnvValue("fromaddress")
+                  valueFrom: createEnvValueFromSecret(secrets.SmtpSecret, "fromaddress")
                 },
                 {
                   name: "RECAPTCHA_SECRET_KEY",
-                  valueFrom: secrets.RecaptchaSecret.asEnvValue("secretKey")
+                  valueFrom: createEnvValueFromSecret(secrets.RecaptchaSecret, "secretKey")
                 }
               ],
             },
@@ -276,7 +277,7 @@ const apiDeployment = new k8s.apps.v1.Deployment(`${commonName}-${apiName}`, {
                 },
                 {
                   name: "RECAPTCHA_SITE_KEY",
-                  valueFrom: secrets.RecaptchaSecret.asEnvValue("siteKey")
+                  valueFrom: createEnvValueFromSecret(secrets.RecaptchaSecret, "siteKey")
                 }
             ]
           }]

--- a/byo-infra/03-application/package.json
+++ b/byo-infra/03-application/package.json
@@ -1,11 +1,11 @@
 {
     "name": "k8s-gke-03-application",
     "devDependencies": {
-        "@types/node": "22.13.10"
+        "@types/node": "22.13.10",
+        "typescript": "^5.8.3"
     },
     "dependencies": {
         "@pulumi/kubernetes": "4.23.0",
-        "@pulumi/kubernetesx": "0.1.6",
         "@pulumi/pulumi": "3.186.0",
         "@pulumi/random": "4.18.3",
         "@pulumi/tls": "5.2.1"

--- a/byo-infra/03-application/secrets.ts
+++ b/byo-infra/03-application/secrets.ts
@@ -1,6 +1,5 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as k8s from "@pulumi/kubernetes";
-import * as kx from "@pulumi/kubernetesx";
 import { Input, Output, ComponentResource, ComponentResourceOptions } from "@pulumi/pulumi";
 
 export interface SecretsCollectionArgs {
@@ -39,22 +38,22 @@ export interface SecretsCollectionArgs {
 }
 
 export class SecretsCollection extends ComponentResource {
-    LicenseKeySecret: kx.Secret;
-    ApiCertificateSecret: kx.Secret;
-    ConsoleCertificateSecret: kx.Secret;
-    DBConnSecret: kx.Secret;
-    StorageSecret: kx.Secret;
-    SmtpSecret: kx.Secret;
-    RecaptchaSecret: kx.Secret;
+    LicenseKeySecret: k8s.core.v1.Secret;
+    ApiCertificateSecret: k8s.core.v1.Secret;
+    ConsoleCertificateSecret: k8s.core.v1.Secret;
+    DBConnSecret: k8s.core.v1.Secret;
+    StorageSecret: k8s.core.v1.Secret;
+    SmtpSecret: k8s.core.v1.Secret;
+    RecaptchaSecret: k8s.core.v1.Secret;
     constructor(name: string, args: SecretsCollectionArgs, opts?: ComponentResourceOptions) {
         super("x:kubernetes:secrets", name, opts);
 
-        this.LicenseKeySecret = new kx.Secret(`${args.commonName}-license-key`, {
+        this.LicenseKeySecret = new k8s.core.v1.Secret(`${args.commonName}-license-key`, {
             metadata: { namespace: args.namespace },
             stringData: { key: args.secretValues.licenseKey },
         }, { provider: args.provider, parent: this });
 
-        this.ApiCertificateSecret = new kx.Secret(`${args.commonName}-api-tls`, {
+        this.ApiCertificateSecret = new k8s.core.v1.Secret(`${args.commonName}-api-tls`, {
             metadata: {
                 namespace: args.namespace
             },
@@ -64,7 +63,7 @@ export class SecretsCollection extends ComponentResource {
             },
         }, { provider: args.provider, parent: this });
 
-        this.ConsoleCertificateSecret = new kx.Secret(`${args.commonName}-console-tls`, {
+        this.ConsoleCertificateSecret = new k8s.core.v1.Secret(`${args.commonName}-console-tls`, {
             metadata: {
                 namespace: args.namespace
             },
@@ -74,7 +73,7 @@ export class SecretsCollection extends ComponentResource {
             },
         }, { provider: args.provider, parent: this });
         
-        this.DBConnSecret = new kx.Secret(`${args.commonName}-mysql-db-conn`, {
+        this.DBConnSecret = new k8s.core.v1.Secret(`${args.commonName}-mysql-db-conn`, {
             metadata: {
                 namespace: args.namespace,
             },
@@ -86,7 +85,7 @@ export class SecretsCollection extends ComponentResource {
             },
           }, { provider: args.provider, parent: this });
 
-        this.StorageSecret = new kx.Secret(`${args.commonName}-storage-secret`, {
+        this.StorageSecret = new k8s.core.v1.Secret(`${args.commonName}-storage-secret`, {
             metadata: {
                 namespace: args.namespace,
             },
@@ -96,7 +95,7 @@ export class SecretsCollection extends ComponentResource {
             }
           }, { provider: args.provider, parent: this });
 
-        this.SmtpSecret = new kx.Secret(`${args.commonName}-smtp-secret`, {
+        this.SmtpSecret = new k8s.core.v1.Secret(`${args.commonName}-smtp-secret`, {
             metadata: {
                 namespace: args.namespace,
             },
@@ -108,7 +107,7 @@ export class SecretsCollection extends ComponentResource {
             }
         }, {provider: args.provider, parent: this});
 
-        this.RecaptchaSecret = new kx.Secret(`${args.commonName}-recaptcha-secret`, {
+        this.RecaptchaSecret = new k8s.core.v1.Secret(`${args.commonName}-recaptcha-secret`, {
             metadata: {
                 namespace: args.namespace
             },

--- a/byo-infra/03-application/sso-cert.ts
+++ b/byo-infra/03-application/sso-cert.ts
@@ -1,17 +1,16 @@
 import * as tls from "@pulumi/tls";
 import {PrivateKey, SelfSignedCert} from "@pulumi/tls";
-import {Secret} from "@pulumi/kubernetesx";
-import {Provider} from "@pulumi/kubernetes";
+import * as k8s from "@pulumi/kubernetes";
 import { Input, ComponentResource, ComponentResourceOptions } from "@pulumi/pulumi";
 
 export interface SsoCertificateArgs {
     apiDomain: string,
     namespace: Input<string>,
-    provider: Provider,
+    provider: k8s.Provider,
 }
 
 export class SsoCertificate extends ComponentResource {
-    public SamlSsoSecret: Secret;
+    public SamlSsoSecret: k8s.core.v1.Secret;
     constructor(name: string, args: SsoCertificateArgs, opts?: ComponentResourceOptions) { 
         super("x:kubernetes:ssocertificate", name, opts);
 
@@ -31,7 +30,7 @@ export class SsoCertificate extends ComponentResource {
             validityPeriodHours: (400*24)
         }, { parent: this })
 
-        this.SamlSsoSecret = new Secret("saml-sso",
+        this.SamlSsoSecret = new k8s.core.v1.Secret("saml-sso",
         {
             metadata: { namespace: args.namespace },
             stringData: {


### PR DESCRIPTION
Replace deprecated @pulumi/kubernetesx package with @pulumi/kubernetes in the BYO infrastructure installer. All Secret resources now use k8s.core.v1.Secret instead of kx.Secret.

Closes #275