### PR TITLE
Add an Access Entry for the K8s resources to show up on the `Resources` tab in the AWS console.

### DIFF
--- a/eks-hosted/05-eks-cluster/config.ts
+++ b/eks-hosted/05-eks-cluster/config.ts
@@ -13,6 +13,7 @@ const eksInstanceRoleName = iamStackRef.requireOutput("eksInstanceRoleName");
 const eksInstanceRole = iamStackRef.requireOutput("eksInstanceRole");
 const eksServiceRoleName = iamStackRef.requireOutput("eksServiceRoleName");
 const eksServiceRole = iamStackRef.requireOutput("eksServiceRole");
+const ssoRoleArn = iamStackRef.requireOutput("ssoRoleArn");
 
 // Networking Stack values
 // Get the needed values from the networking stack.
@@ -53,6 +54,7 @@ export const config = {
     eksInstanceRole: eksInstanceRole,
     eksServiceRoleName: eksServiceRoleName,
     eksServiceRole: eksServiceRole,
+    ssoRoleArn: ssoRoleArn,
 
     // Networking stack values
     clusterName: clusterName,

--- a/eks-hosted/05-eks-cluster/index.ts
+++ b/eks-hosted/05-eks-cluster/index.ts
@@ -23,6 +23,21 @@ const cluster = new eks.Cluster(`${baseName}`, {
     skipDefaultNodeGroup: true,
     version: config.clusterVersion,
     createOidcProvider: false,
+    accessEntries: {
+        "portaladmin": {
+            principalArn: config.ssoRoleArn,
+            accessPolicies: {
+                "dummy": {
+                    policyArn: "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy",
+                    accessScope: {
+                        type: "cluster",
+                        namespaces: []
+                    }
+                }
+            },
+            type: "STANDARD"
+        }
+    },
     tags: tags,
     enabledClusterLogTypes: ["api", "audit", "authenticator", "controllerManager", "scheduler"],
 }, { protect: true });


### PR DESCRIPTION
Adding this access entry will allow us to see all deployed resources on the EKS cluster to be browsable in the `Resources` tab within the AWS console.