### PR TITLE
feat: migrate AKS installer from archived @pulumi/kubernetesx 

### DIFF
--- a/aks-hosted/03-application/index.ts
+++ b/aks-hosted/03-application/index.ts
@@ -4,6 +4,7 @@ import { getConfig } from "./config";
 import { SecretsCollection } from "./secrets";
 import { SsoCertificate } from "./sso-cert";
 import { CertManagerDeployment } from "./cert-manager";
+import { createEnvValueFromSecret } from "./secret-utils";
 
 export = async () => {
   /**
@@ -91,19 +92,19 @@ export = async () => {
             env: [
               {
                 name: "PULUMI_DATABASE_ENDPOINT",
-                valueFrom: secrets.DBConnSecret.asEnvValue("host"),
+                valueFrom: createEnvValueFromSecret(secrets.DBConnSecret, "host"),
               },
               {
                 name: "MYSQL_ROOT_USERNAME",
-                valueFrom: secrets.DBConnSecret.asEnvValue("username"),
+                valueFrom: createEnvValueFromSecret(secrets.DBConnSecret, "username"),
               },
               {
                 name: "MYSQL_ROOT_PASSWORD",
-                valueFrom: secrets.DBConnSecret.asEnvValue("password"),
+                valueFrom: createEnvValueFromSecret(secrets.DBConnSecret, "password"),
               },
               {
                 name: "PULUMI_DATABASE_PING_ENDPOINT",
-                valueFrom: secrets.DBConnSecret.asEnvValue("host"),
+                valueFrom: createEnvValueFromSecret(secrets.DBConnSecret, "host"),
               },
               {
                 name: "RUN_MIGRATIONS_EXTERNALLY",
@@ -120,7 +121,7 @@ export = async () => {
               env: [
                 {
                   name: "PULUMI_LICENSE_KEY",
-                  valueFrom: secrets.LicenseKeySecret.asEnvValue("key"),
+                  valueFrom: createEnvValueFromSecret(secrets.LicenseKeySecret, "key"),
                 },
                 {
                   name: "PULUMI_ENTERPRISE",
@@ -136,15 +137,15 @@ export = async () => {
                 },
                 {
                   name: "PULUMI_DATABASE_ENDPOINT",
-                  valueFrom: secrets.DBConnSecret.asEnvValue("host"),
+                  valueFrom: createEnvValueFromSecret(secrets.DBConnSecret, "host"),
                 },
                 {
                   name: "PULUMI_DATABASE_USER_NAME",
-                  valueFrom: secrets.DBConnSecret.asEnvValue("username"),
+                  valueFrom: createEnvValueFromSecret(secrets.DBConnSecret, "username"),
                 },
                 {
                   name: "PULUMI_DATABASE_USER_PASSWORD",
-                  valueFrom: secrets.DBConnSecret.asEnvValue("password"),
+                  valueFrom: createEnvValueFromSecret(secrets.DBConnSecret, "password"),
                 },
                 {
                   name: "PULUMI_DATABASE_NAME",
@@ -152,11 +153,11 @@ export = async () => {
                 },
                 {
                   name: "SAML_CERTIFICATE_PUBLIC_KEY",
-                  valueFrom: ssoSecret.SamlSsoSecret.asEnvValue("pubkey")
+                  valueFrom: createEnvValueFromSecret(ssoSecret.SamlSsoSecret, "pubkey")
                 },
                 {
                   name: "SAML_CERTIFICATE_PRIVATE_KEY",
-                  valueFrom: ssoSecret.SamlSsoSecret.asEnvValue("privatekey")
+                  valueFrom: createEnvValueFromSecret(ssoSecret.SamlSsoSecret, "privatekey")
                 },
                 {
                   name: "AZURE_CLIENT_ID",
@@ -204,23 +205,23 @@ export = async () => {
                 },
                 {
                   name: "SMTP_SERVER",
-                  valueFrom: secrets.SmtpSecret.asEnvValue("server"),
+                  valueFrom: createEnvValueFromSecret(secrets.SmtpSecret, "server"),
                 },
                 {
                   name: "SMTP_USERNAME",
-                  valueFrom: secrets.SmtpSecret.asEnvValue("username"),
+                  valueFrom: createEnvValueFromSecret(secrets.SmtpSecret, "username"),
                 },
                 {
                   name: "SMTP_PASSWORD",
-                  valueFrom: secrets.SmtpSecret.asEnvValue("password"),
+                  valueFrom: createEnvValueFromSecret(secrets.SmtpSecret, "password"),
                 },
                 {
                   name: "SMTP_GENERIC_SENDER",
-                  valueFrom: secrets.SmtpSecret.asEnvValue("fromaddress")
+                  valueFrom: createEnvValueFromSecret(secrets.SmtpSecret, "fromaddress")
                 },
                 {
                   name: "RECAPTCHA_SECRET_KEY",
-                  valueFrom: secrets.RecaptchaSecret.asEnvValue("secretKey")
+                  valueFrom: createEnvValueFromSecret(secrets.RecaptchaSecret, "secretKey")
                 }
               ],
             },
@@ -285,7 +286,7 @@ export = async () => {
               },
               {
                 name: "RECAPTCHA_SITE_KEY",
-                valueFrom: secrets.RecaptchaSecret.asEnvValue("siteKey")
+                valueFrom: createEnvValueFromSecret(secrets.RecaptchaSecret, "siteKey")
               }
             ]
           }]

--- a/aks-hosted/03-application/package.json
+++ b/aks-hosted/03-application/package.json
@@ -5,7 +5,6 @@
     },
     "dependencies": {
         "@pulumi/kubernetes": "^4.0.0",
-        "@pulumi/kubernetesx": "^0.1.6",
         "@pulumi/pulumi": "^3.116.1",
         "@pulumi/random": "^4.16.1",
         "@pulumi/tls": "^5.0.3"

--- a/aks-hosted/03-application/secret-utils.ts
+++ b/aks-hosted/03-application/secret-utils.ts
@@ -1,0 +1,10 @@
+import * as k8s from "@pulumi/kubernetes";
+
+export function createEnvValueFromSecret(secret: k8s.core.v1.Secret, key: string) {
+    return {
+        secretKeyRef: {
+            name: secret.metadata.name,
+            key: key
+        }
+    };
+}

--- a/aks-hosted/03-application/secrets.ts
+++ b/aks-hosted/03-application/secrets.ts
@@ -1,11 +1,10 @@
-import { Provider } from "@pulumi/kubernetes";
-import { Secret } from "@pulumi/kubernetesx";
+import * as k8s from "@pulumi/kubernetes";
 import { Input, Output, ComponentResource, ComponentResourceOptions, interpolate } from "@pulumi/pulumi";
 
 export interface SecretsCollectionArgs {
     namespace: Input<string>,
     commonName: string,
-    provider: Provider,
+    provider: k8s.Provider,
     apiDomain: Input<string>
     secretValues: {
         licenseKey: Input<string>,
@@ -33,23 +32,23 @@ export interface SecretsCollectionArgs {
 }
 
 export class SecretsCollection extends ComponentResource {
-    LicenseKeySecret: Secret;
-    ApiCertificateSecret: Secret | undefined;
-    ConsoleCertificateSecret: Secret | undefined;
-    DBConnSecret: Secret;
-    SmtpSecret: Secret;
-    RecaptchaSecret: Secret;
+    LicenseKeySecret: k8s.core.v1.Secret;
+    ApiCertificateSecret: k8s.core.v1.Secret | undefined;
+    ConsoleCertificateSecret: k8s.core.v1.Secret | undefined;
+    DBConnSecret: k8s.core.v1.Secret;
+    SmtpSecret: k8s.core.v1.Secret;
+    RecaptchaSecret: k8s.core.v1.Secret;
     constructor(name: string, args: SecretsCollectionArgs, opts?: ComponentResourceOptions) {
         super("x:kubernetes:secrets", name, opts);
 
-        this.LicenseKeySecret = new Secret(`${args.commonName}-license-key`, {
+        this.LicenseKeySecret = new k8s.core.v1.Secret(`${args.commonName}-license-key`, {
             metadata: { namespace: args.namespace },
             stringData: { key: args.secretValues.licenseKey },
         }, { provider: args.provider, parent: this });
 
         // TODO: if cert-manager is enabled do not create api/console certs
         if (args.secretValues.apiTlsCert && args.secretValues.apiTlsKey) {
-            this.ApiCertificateSecret = new Secret(`${args.commonName}-api-tls`, {
+            this.ApiCertificateSecret = new k8s.core.v1.Secret(`${args.commonName}-api-tls`, {
                 metadata: {
                     namespace: args.namespace
                 },
@@ -61,7 +60,7 @@ export class SecretsCollection extends ComponentResource {
         }
 
         if (args.secretValues.consoleTlsCert && args.secretValues.consoleTlsKey) {
-            this.ConsoleCertificateSecret = new Secret(`${args.commonName}-console-tls`, {
+            this.ConsoleCertificateSecret = new k8s.core.v1.Secret(`${args.commonName}-console-tls`, {
                 metadata: {
                     namespace: args.namespace
                 },
@@ -72,7 +71,7 @@ export class SecretsCollection extends ComponentResource {
             }, { provider: args.provider, parent: this });
         }
         
-        this.DBConnSecret = new Secret(`${args.commonName}-mysql-db-conn`, {
+        this.DBConnSecret = new k8s.core.v1.Secret(`${args.commonName}-mysql-db-conn`, {
             metadata: {
                 namespace: args.namespace,
             },
@@ -84,7 +83,7 @@ export class SecretsCollection extends ComponentResource {
         }, { provider: args.provider, parent: this });
 
 
-        this.SmtpSecret = new Secret(`${args.commonName}-smtp-secret`, {
+        this.SmtpSecret = new k8s.core.v1.Secret(`${args.commonName}-smtp-secret`, {
             metadata: {
                 namespace: args.namespace,
             },
@@ -96,7 +95,7 @@ export class SecretsCollection extends ComponentResource {
             }
         }, { provider: args.provider, parent: this });
 
-        this.RecaptchaSecret = new Secret(`${args.commonName}-recaptcha-secret`, {
+        this.RecaptchaSecret = new k8s.core.v1.Secret(`${args.commonName}-recaptcha-secret`, {
             metadata: {
                 namespace: args.namespace
             },

--- a/aks-hosted/03-application/sso-cert.ts
+++ b/aks-hosted/03-application/sso-cert.ts
@@ -1,16 +1,15 @@
 import { PrivateKey, SelfSignedCert } from "@pulumi/tls";
-import { Secret } from "@pulumi/kubernetesx";
-import { Provider } from "@pulumi/kubernetes";
+import * as k8s from "@pulumi/kubernetes";
 import { Input, ComponentResource, ComponentResourceOptions } from "@pulumi/pulumi";
 
 export interface SsoCertificateArgs {
     apiDomain: string,
     namespace: Input<string>,
-    provider: Provider,
+    provider: k8s.Provider,
 }
 
 export class SsoCertificate extends ComponentResource {
-    public SamlSsoSecret: Secret;
+    public SamlSsoSecret: k8s.core.v1.Secret;
     constructor(name: string, args: SsoCertificateArgs, opts?: ComponentResourceOptions) {
         super("x:kubernetes:ssocertificate", name, opts);
 
@@ -31,7 +30,7 @@ export class SsoCertificate extends ComponentResource {
             validityPeriodHours: (400 * 24)
         }, { parent: this })
 
-        this.SamlSsoSecret = new Secret("saml-sso",
+        this.SamlSsoSecret = new k8s.core.v1.Secret("saml-sso",
             {
                 metadata: { namespace: args.namespace },
                 stringData: {

--- a/byo-infra/03-application/secret-utils.ts
+++ b/byo-infra/03-application/secret-utils.ts
@@ -1,0 +1,10 @@
+import * as k8s from "@pulumi/kubernetes";
+
+export function createEnvValueFromSecret(secret: k8s.core.v1.Secret, key: string) {
+    return {
+        secretKeyRef: {
+            name: secret.metadata.name,
+            key: key
+        }
+    };
+}


### PR DESCRIPTION
- Remove @pulumi/kubernetesx dependency from aks-hosted/03-application/package.json
- Replace kubernetesx.Secret with k8s.core.v1.Secret in secrets.ts and sso-cert.ts
- Add createEnvValueFromSecret helper function to replace asEnvValue() method
- Update all 16 environment variable references in index.ts to use helper function
- Maintain 100% functional compatibility with standard Kubernetes Secret API

Resolves #274