### PR TITLE
chore: adding in pulumi-renovate[bot]

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,6 +9,7 @@ jobs:
     if: |
       github.event.pull_request.user.login != 'dependabot' &&
       github.event.pull_request.user.login != 'pulumi-renovate' &&
+      github.event.pull_request.user.login != 'pulumi-renovate[bot]' &&
       github.event.pull_request.user.login != 'pulumi-bot'
     
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request makes a small update to the workflow conditions in `.github/workflows/claude-code-review.yml`, adding an additional check to exclude the `pulumi-renovate[bot]` user from triggering the workflow.