### PR TITLE
fix(eks): update deprecated environment variables in migrations container

### DIFF
--- a/eks-hosted/90-pulumi-service/index.ts
+++ b/eks-hosted/90-pulumi-service/index.ts
@@ -147,8 +147,8 @@ const apiDeployment = new k8s.apps.v1.Deployment(`${commonName}-${apiName}`, {
             resources: migrationResources,
             env: [
               generateEnvVarFromSecret("PULUMI_DATABASE_ENDPOINT", secrets.DBConnSecret.metadata.name, "endpoint"),
-              generateEnvVarFromSecret("MYSQL_ROOT_USERNAME", secrets.DBConnSecret.metadata.name, "username"),
-              generateEnvVarFromSecret("MYSQL_ROOT_PASSWORD", secrets.DBConnSecret.metadata.name, "password"),
+              generateEnvVarFromSecret("PULUMI_LOCAL_DB_SUPERUSER", secrets.DBConnSecret.metadata.name, "username"),
+              generateEnvVarFromSecret("PULUMI_LOCAL_DB_PASSWORD", secrets.DBConnSecret.metadata.name, "password"),
               generateEnvVarFromSecret("PULUMI_DATABASE_PING_ENDPOINT", secrets.DBConnSecret.metadata.name, "host"),
               {
                   name: "RUN_MIGRATIONS_EXTERNALLY",


### PR DESCRIPTION
Replace deprecated MySQL-specific environment variables with current Pulumi-specific ones:
- MYSQL_ROOT_USERNAME → PULUMI_LOCAL_DB_SUPERUSER  
- MYSQL_ROOT_PASSWORD → PULUMI_LOCAL_DB_PASSWORD

This aligns with the official Pulumi Self-Hosted Service documentation and brings
the EKS installer in line with current best practices.

Fixes #56