### PR TITLE
adding additional step for agGridLicense key

### DIFF
--- a/aks-hosted/README.md
+++ b/aks-hosted/README.md
@@ -112,6 +112,7 @@ The following settings are optional.
 * `pulumi config set apiDomain {domain for api}`
 * `pulumi config set consoleDomain {domain for console}`
 * `pulumi config set licenseKey {licenseKey} --secret`
+* `pulumi config set agGridLicenseKey {agGridLicenseKey} --secret`
 * `pulumi config set imageTag {imageTag}`
 * `pulumi config set samlEnabled {true | false}` - If not configuring SAML SSO initially, skip or set to false.
 

--- a/byo-infra/README.md
+++ b/byo-infra/README.md
@@ -108,6 +108,7 @@ Optional settings (will use default values if not set)
 1. `pulumi config set apiDomain {domain for api}` - e.g. api.pulumi.example.com (must start with "api")
 1. `pulumi config set consoleDomain {domain for console}` - e.g. app.pulumi.example.com (must start with "app")
 1. `pulumi config set licenseKey {licenseKey} --secret` - the license key is available from your Pulumi contact.
+* `pulumi config set agGridLicenseKey {agGridLicenseKey} --secret` the license key is available from your Pulumi contact.
 1. `pulumi config set imageTag {imageTag}` - use "latest" or find the latest tag to pin to here: https://hub.docker.com/r/pulumi/service
 1. `cat {path to api key file} | pulumi config set apiTlsKey --secret --` (on a mac or linux machine)
 1. `cat {path to api cert file} | pulumi config set apiTlsCert --secret --` (on a mac or linux machine)

--- a/ecs-hosted/go/README.md
+++ b/ecs-hosted/go/README.md
@@ -220,6 +220,7 @@ The Pulumi services operate in AWS Elastic Container Service (ECS) with the foll
     pulumi config set acmCertificateArn arn:aws:acm:us-west-2:052848974346:certificate/ee6d246c-dd3a-4667-b58a-4568a0f72dd6
     pulumi config set kmsServiceKeyId f7f56e09-f568-447c-8540-cef8ba122a79
     pulumi config set licenseKey {value} --secret
+    pulumi config set agGridLicenseKey {agGridLicenseKey} --secret
     pulumi config set logType awslogs
     pulumi config set logArgs '{"name": "pulumi-selfhosted", "retentionInDays": 3}'
     pulumi config set privateSubnetIds '[ "subnet-03fd1ba00d1ff893c","subnet-09a443b2aece32800","subnet-0f89dff186bdd1f56"]'

--- a/ecs-hosted/ts/README.md
+++ b/ecs-hosted/ts/README.md
@@ -229,6 +229,7 @@ pulumi config set imageTag 20220105-189-signed
 pulumi config set acmCertificateArn arn:aws:acm:us-west-2:052848974346:certificate/ee6d246c-dd3a-4667-b58a-4568a0f72dd6
 pulumi config set kmsServiceKeyId f7f56e09-f568-447c-8540-cef8ba122a79
 pulumi config set licenseKey {value} --secret
+pulumi config set agGridLicenseKey {agGridLicenseKey} --secret
 pulumi config set logType awslogs
 pulumi config set logArgs '{"name": "pulumi-selfhosted", "retentionInDays": 3}'
 pulumi config set privateSubnetIds '[ "subnet-03fd1ba00d1ff893c","subnet-09a443b2aece32800","subnet-0f89dff186bdd1f56"]'

--- a/gke-hosted/README.md
+++ b/gke-hosted/README.md
@@ -95,6 +95,7 @@ Optional settings (will use default values if not set)
 1. `pulumi config set apiDomain {domain for api}` - e.g. api.pulumi.example.com (must start with "api")
 1. `pulumi config set consoleDomain {domain for console}` - e.g. app.pulumi.example.com (must start with "app")
 1. `pulumi config set licenseKey {licenseKey} --secret` - the license key is available from your Pulumi contact.
+1. `pulumi config set agGridLicenseKey {agGridLicenseKey} --secret` - the license key is available from your Pulumi contact.
 1. `pulumi config set imageTag {imageTag}` - use "latest" or find the latest tag to pin to here: https://hub.docker.com/r/pulumi/service
 1. `cat {path to api key file} | pulumi config set apiTlsKey --secret --` (on a mac or linux machine)
 1. `cat {path to api cert file} | pulumi config set apiTlsCert --secret --` (on a mac or linux machine)


### PR DESCRIPTION
To prevent the AG Grid watermark, we will have to instruct self-hosted users to set an `agGridLicenseKey` value.  I have added this to 1Password under the same name.  