### PR TITLE
chore: fixing autoapprove

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -35,7 +35,8 @@ jobs:
 
       - name: Auto-merge if tests pass
         if: steps.wait-for-tests.outputs.conclusion == 'success'
-        uses: pascalgn/merge-action@22e93c6abb5336a0ed86e67c83a4a99f5306db2b # v0.22.2
+        uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          merge_method: squash
+          token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: squash
+          pull-request-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
This pull request updates the auto-merge step in the GitHub Actions workflow to use a different action for enabling pull request automerge. The main change is replacing the `pascalgn/merge-action` with `peter-evans/enable-pull-request-automerge`, along with updating input parameters to match the new action's requirements.

Workflow automation update:

* Replaced `pascalgn/merge-action` with `peter-evans/enable-pull-request-automerge@v3` in `.github/workflows/auto-approve.yml`, and updated the input parameters to use `token`, `merge-method`, and `pull-request-number` as required by the new action.