### PR TITLE
chore: updating renovate configuration

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,6 +6,9 @@
   automerge: true,
   automergeType: "pr",
   automergeStrategy: "squash",
+  rebaseWhen: "behind-base-branch",  // Auto-rebase when behind main
+  platformAutomerge: true,            // Use GitHub's native auto-merge
+  prConcurrentLimit: 10,              // Limit concurrent PRs to reduce noise  
   
   // Ignore specific paths
   ignorePaths: [


### PR DESCRIPTION
This pull request updates the Renovate configuration to improve automation and management of dependency updates. The main changes focus on enabling auto-rebase, leveraging GitHub's native auto-merge, and limiting concurrent pull requests.

**Automation improvements:**

* Enabled auto-rebase of dependency update branches when they fall behind the base branch by setting `rebaseWhen` to `"behind-base-branch"`.
* Activated GitHub's native auto-merge feature with `platformAutomerge: true`.

**PR management enhancements:**

* Set `prConcurrentLimit` to `10` to reduce noise by limiting the number of concurrent Renovate pull requests.