### PR TITLE
fix: Fix PULUMI_LICENSE_KEY environment variable handling in docker-compose

### DIFF
--- a/quickstart-docker-compose/all-in-one/docker-compose.yml
+++ b/quickstart-docker-compose/all-in-one/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     # Only the keys of such environment variables must be listed below. The value part must be left
     # empty here.
     environment:
-      PULUMI_LICENSE_KEY:
+      PULUMI_LICENSE_KEY: ${PULUMI_LICENSE_KEY}
       PULUMI_ENTERPRISE: "true"
       PULUMI_DATABASE_NAME: "pulumi"
       # Used for SAML SSO. Endpoint must be reachable by clients either

--- a/quickstart-docker-compose/docker-compose.yml
+++ b/quickstart-docker-compose/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     image: "pulumi/service:latest@sha256:070af53945b61af7898569ee59defed9ebbdc661782958b32ee326987bbbc62a"
     env_file: service_vars.env
     environment:
-      PULUMI_LICENSE_KEY:
+      PULUMI_LICENSE_KEY: ${PULUMI_LICENSE_KEY}
       PULUMI_ENTERPRISE: "true"
       PULUMI_DATABASE_NAME: "pulumi"
       # Used for SAML SSO. Endpoint must be reachable by clients either

--- a/quickstart-docker-compose/service_vars.env
+++ b/quickstart-docker-compose/service_vars.env
@@ -7,6 +7,8 @@
 # settings in this file.
 
 PULUMI_ENTERPRISE=true
+# Set your Pulumi license key here. You can also set this as an environment variable.
+# Example: PULUMI_LICENSE_KEY=your-license-key-here
 PULUMI_LICENSE_KEY=
 
 # Database


### PR DESCRIPTION
This PR fixes the issue where setting PULUMI_LICENSE_KEY in docker compose YAML files doesn't work.

## Changes
- Updated docker-compose files to use `${PULUMI_LICENSE_KEY}` syntax instead of empty declaration
- Added helpful comments to service_vars.env with usage example
- Now users can set the license key in service_vars.env file as expected

## Root Cause
The previous syntax `PULUMI_LICENSE_KEY:` only passed through environment variables from the host, but didn't read from the .env file.

Resolves #815

🤖 Generated with [Claude Code](https://claude.ai/code)