### PR TITLE
adding jsonschema v6 to excludes

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -39,9 +39,17 @@
       // Disable updates for OpenSearch
       matchDatasources: ["docker"],
       matchPackageNames: [
-        "opensearch/opensearch", 
+        "opensearch/opensearch",
         "opensearchproject/opensearch",
       ],
+      enabled: false,
+    },
+    {
+      // Disable major updates for jsonschema — it's an indirect dependency
+      // pulled in by pulumi/pulumi SDK and pulumi/esc, which still use v5.
+      // v6 has breaking API changes; upgrade is blocked until upstream migrates.
+      matchPackageNames: ["github.com/santhosh-tekuri/jsonschema/v5"],
+      matchUpdateTypes: ["major"],
       enabled: false,
     },
   ],


### PR DESCRIPTION
This pull request makes a small configuration change to the `renovate.json5` file. The change disables major updates for the indirect dependency `jsonschema`, which is required to remain at version 5 due to upstream constraints.

* Renovate configuration: Added a rule to disable major updates for `github.com/santhosh-tekuri/jsonschema/v5`, since upgrading to v6 is blocked by upstream dependencies (`pulumi/pulumi` SDK and `pulumi/esc`).