### PR TITLE
Pin migratecli build to fixed pseudo-version

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -10,6 +10,15 @@ on:
 name: PR test
 
 jobs:
+  script-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - name: Test migrate-db.sh's migrate/migratecli discovery logic
+        run: ./quickstart-docker-compose/scripts/migrate-db_test.sh
+
   test:
 
     runs-on: ubuntu-latest

--- a/quickstart-docker-compose/scripts/migrate-db.sh
+++ b/quickstart-docker-compose/scripts/migrate-db.sh
@@ -14,11 +14,11 @@ cd "$(dirname "${BASH_SOURCE}")/.."
 
 echo "Running migrations"
 
-# Ensure that the migratecli tool is installed already.
+# Ensure that the migrate tool is installed already.
 # When this script is run inside the `pulumi/migrations` container,
 # this tool is pre-installed as part of creating the container image.
-which migratecli >/dev/null || {
-    echo "Building 'migratecli' from source."
+which migrate >/dev/null || {
+    echo "Building 'migrate' from source."
     # Pinned to match the pulumi/migrations container image; sync with the
     # service repo's migrations/Dockerfile and go.mod when bumping.
     MIGRATECLI_VERSION="v4.13.2-0.20260317180800-e25d528f435d"
@@ -28,8 +28,6 @@ which migratecli >/dev/null || {
         -tags=mysql \
         -ldflags="-X main.Version=${MIGRATECLI_VERSION}" \
         "github.com/pulumi/golang-migrate/v4/cmd/migrate@${MIGRATECLI_VERSION}"
-    # Rename to migratecli — that's the name our scripts expect.
-    mv "${INSTALL_DEST}/migrate" "${INSTALL_DEST}/migratecli"
 
     # Ensure the version we built is on the PATH for the rest of this script
     export PATH="${INSTALL_DEST}:${PATH}"
@@ -91,7 +89,7 @@ fi
 
 skip_first_migration() {
     echo "NOTE: Skipping the first migration script. You will need to set the PULUMI_DATABASE_USER_NAME and PULUMI_DATABASE_USER_PASSWORD environment variables in the API container, to specify a custom database user name and password for your service instance."
-    migratecli -path "${MIGRATIONS_DIR}" -database "${DB_CONNECTION_STRING}" force 1
+    migrate -path "${MIGRATIONS_DIR}" -database "${DB_CONNECTION_STRING}" force 1
 }
 
 # Force the migration to 1 if the option to skip creation of the
@@ -101,7 +99,7 @@ if [ -n "${SKIP_CREATE_DB_USER:-}" ]; then
     # Since this script sets errexit option at the beginning, we should ensure that the command
     # failure is captured properly or the script will stop at the first failed command. Redirecting
     # the output alone is not enough.
-    current_version=$(migratecli -path "${MIGRATIONS_DIR}" -database "${DB_CONNECTION_STRING}" version 2>&1) || {
+    current_version=$(migrate -path "${MIGRATIONS_DIR}" -database "${DB_CONNECTION_STRING}" version 2>&1) || {
         # Skip the first migration script only if the error is because there isn't a previous
         # migration. We do a regexp search here for the string "no migration".
         if [[ "${current_version}" == *"no migration"* ]]; then
@@ -117,4 +115,4 @@ if [ -n "${SKIP_CREATE_DB_USER:-}" ]; then
 fi
 
 # Options are only recognized if they come *before* the command.
-migratecli -path "${MIGRATIONS_DIR}" -database "${DB_CONNECTION_STRING}" up
+migrate -path "${MIGRATIONS_DIR}" -database "${DB_CONNECTION_STRING}" up

--- a/quickstart-docker-compose/scripts/migrate-db.sh
+++ b/quickstart-docker-compose/scripts/migrate-db.sh
@@ -19,14 +19,17 @@ echo "Running migrations"
 # this tool is pre-installed as part of creating the container image.
 which migratecli >/dev/null || {
     echo "Building 'migratecli' from source."
-    CLONE_DIR="${GOPATH}/src/github.com/pulumi/golang-migrate"
-    git clone git@github.com:pulumi/golang-migrate.git "${CLONE_DIR}"
-    pushd "${CLONE_DIR}"
-    # https://github.com/golang-migrate/migrate/blob/master/CONTRIBUTING.md
+    # Pinned to match the pulumi/migrations container image; sync with the
+    # service repo's migrations/Dockerfile and go.mod when bumping.
+    MIGRATECLI_VERSION="v4.13.2-0.20260317180800-e25d528f435d"
     INSTALL_DEST=${GOBIN:-$(go env GOPATH)/bin}
-
-    DATABASE=mysql SOURCE=file CLI_BUILD_OUTPUT=${INSTALL_DEST}/migratecli make build-cli
-    popd
+    mkdir -p "${INSTALL_DEST}"
+    GOBIN="${INSTALL_DEST}" CGO_ENABLED=0 go install \
+        -tags=mysql \
+        -ldflags="-X main.Version=${MIGRATECLI_VERSION}" \
+        "github.com/pulumi/golang-migrate/v4/cmd/migrate@${MIGRATECLI_VERSION}"
+    # Rename to migratecli — that's the name our scripts expect.
+    mv "${INSTALL_DEST}/migrate" "${INSTALL_DEST}/migratecli"
 
     # Ensure the version we built is on the PATH for the rest of this script
     export PATH="${INSTALL_DEST}:${PATH}"

--- a/quickstart-docker-compose/scripts/migrate-db_test.sh
+++ b/quickstart-docker-compose/scripts/migrate-db_test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Exercises the migrate-tool discovery/build logic in migrate-db.sh in
+# isolation (no real database), by stubbing `migrate` and `go` on PATH.
+# Guards against a regression to the old `migratecli` binary name.
+
+set -o nounset -o errexit -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE}")" && pwd)"
+MIGRATE_SCRIPT="${SCRIPT_DIR}/migrate-db.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# A fake `migrate` binary: logs its argv (one line, space-joined) to
+# $MIGRATE_CALL_LOG and exits 0.
+write_migrate_stub() {
+    local dest="$1"
+    cat > "${dest}" <<'STUB'
+#!/usr/bin/env bash
+echo "$*" >> "${MIGRATE_CALL_LOG}"
+exit 0
+STUB
+    chmod +x "${dest}"
+}
+
+# --- scenario 1: `migrate` already on PATH -> no build step, invoked directly ---
+test_preinstalled_migrate() {
+    local workdir; workdir=$(mktemp -d "${TMPDIR:-/tmp}/migrate-db-test.XXXXXX")
+    local bindir="${workdir}/bin"
+    mkdir -p "${bindir}"
+    write_migrate_stub "${bindir}/migrate"
+
+    MIGRATE_CALL_LOG="${workdir}/calls" \
+    PULUMI_LOCAL_DATABASE_NAME=pulumi \
+    PATH="${bindir}:${PATH}" \
+        bash "${MIGRATE_SCRIPT}" > "${workdir}/stdout" 2>&1 || {
+            cat "${workdir}/stdout" >&2
+            fail "script exited non-zero with 'migrate' already on PATH"
+        }
+
+    grep -q "Building 'migrate' from source" "${workdir}/stdout" && \
+        fail "script tried to build migrate even though it was already on PATH"
+
+    grep -qE '^-path .* up$' "${workdir}/calls" || \
+        fail "expected a 'migrate -path ... up' invocation, got: $(cat "${workdir}/calls" 2>/dev/null || echo '<no calls>')"
+
+    echo "PASS: pre-installed 'migrate' is used as-is (no build, no migratecli)"
+}
+
+# --- scenario 2: `migrate` missing -> falls back to `go install`, then uses the result ---
+test_build_from_source() {
+    local workdir; workdir=$(mktemp -d "${TMPDIR:-/tmp}/migrate-db-test.XXXXXX")
+    local gobin="${workdir}/gobin"
+    local gostubdir="${workdir}/gostub"
+    mkdir -p "${gobin}" "${gostubdir}"
+
+    # What `go install` "produces": reuse the same logging stub as scenario 1.
+    local migrate_template="${workdir}/migrate-template"
+    write_migrate_stub "${migrate_template}"
+
+    cat > "${gostubdir}/go" <<STUB
+#!/usr/bin/env bash
+if [ "\$1" = "env" ] && [ "\$2" = "GOPATH" ]; then
+    echo "${workdir}/gopath"
+    exit 0
+fi
+if [ "\$1" = "install" ]; then
+    mkdir -p "\${GOBIN}"
+    cp "${migrate_template}" "\${GOBIN}/migrate"
+    exit 0
+fi
+echo "unexpected go invocation: \$*" >&2
+exit 1
+STUB
+    chmod +x "${gostubdir}/go"
+
+    MIGRATE_CALL_LOG="${workdir}/calls" \
+    GOBIN="${gobin}" \
+    PULUMI_LOCAL_DATABASE_NAME=pulumi \
+    PATH="${gostubdir}:${PATH}" \
+        bash "${MIGRATE_SCRIPT}" > "${workdir}/stdout" 2>&1 || {
+            cat "${workdir}/stdout" >&2
+            fail "script exited non-zero while building 'migrate' from source"
+        }
+
+    grep -q "Building 'migrate' from source" "${workdir}/stdout" || \
+        fail "expected the build-from-source path to run when 'migrate' isn't on PATH"
+
+    [ -x "${gobin}/migrate" ] || \
+        fail "go install did not produce a binary named 'migrate' (regression to 'migratecli'?)"
+    [ -e "${gobin}/migratecli" ] && \
+        fail "go install (or the script) produced a stray 'migratecli' binary — rename incomplete"
+
+    grep -qE '^-path .* up$' "${workdir}/calls" || \
+        fail "expected the freshly built 'migrate' binary to be invoked, got: $(cat "${workdir}/calls" 2>/dev/null || echo '<no calls>')"
+
+    echo "PASS: build-from-source path installs and invokes 'migrate' (not 'migratecli')"
+}
+
+test_preinstalled_migrate
+test_build_from_source


### PR DESCRIPTION
## Summary

Replaces the `git clone + make build-cli` migratecli fallback with a pinned
`go install` of the same pseudo-version that the `pulumi/migrations` container
image is built from (`v4.13.2-0.20260317180800-e25d528f435d`). Users who run
this script outside the container (where the tool isn't pre-installed) now
get a reproducible build instead of HEAD of `pulumi/golang-migrate`.

Also along the way:
- `-tags=mysql` (drops the no-op `file` tag at this version — `source/file` is
  unconditionally imported in `internal/cli/commands.go`).
- `-ldflags '-X main.Version=...'` so `migrate -version` reports the pin
  instead of `dev`.
- `CGO_ENABLED=0` to match the container image (static binary).
- Renamed the local `migratecli` binary/references to `migrate`, matching the
  upstream binary name and the `pulumi/migrations` container image, which
  installs at `/usr/local/bin/migrate` (keeping a `migratecli` symlink for
  backward compat during the transition).
- Added `quickstart-docker-compose/scripts/migrate-db_test.sh`, a
  regression test that stubs `migrate`/`go` on PATH to exercise both the
  pre-installed and build-from-source code paths without a real database,
  and fails if either path produces or invokes the old `migratecli` name.
  Wired into `pr-test.yml` as an independent `script-test` job.

## Dependencies / ordering

Part of a three-PR chain with
[pulumi/pulumi-service#43764](https://github.com/pulumi/pulumi-service/pull/43764)
(origin of the pseudo-version pin, updates `migrations/Dockerfile` to build
and publish this same binary) and, further out,
[pulumi/golang-migrate#17](https://github.com/pulumi/golang-migrate/pull/17)
(fork sync to upstream, independent prep). This PR has no live effect until
`#43764` merges, the `pulumi/migrations` image is rebuilt, and the image
digest pinned in `quickstart-docker-compose/all-in-one/docker-compose*.yml`
is bumped in a follow-up PR — the currently pinned image runs its own frozen,
baked-in copy of this script, unaffected by this change.

## Test plan

- [x] `quickstart-docker-compose/scripts/migrate-db_test.sh` (new, runs in CI
      as the `script-test` job): pre-installed `migrate` short-circuits the
      build; a missing `migrate` falls back to `go install` and the result is
      used — neither path touches `migratecli`.
- [x] Verify `which migrate` short-circuit still works when it's already on PATH.
- [x] On a host without the tool pre-installed, confirm the new `go install` path produces a working binary.
- [x] `migrate -version` reports `v4.13.2-0.20260317180800-e25d528f435d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
