### PR TITLE
Bump pinned migratecli to v4.19.1-pulumi.1

### DIFF
--- a/quickstart-docker-compose/scripts/migrate-db.sh
+++ b/quickstart-docker-compose/scripts/migrate-db.sh
@@ -21,7 +21,7 @@ which migrate >/dev/null || {
     echo "Building 'migrate' from source."
     # Pinned to match the pulumi/migrations container image; sync with the
     # service repo's migrations/Dockerfile and go.mod when bumping.
-    MIGRATECLI_VERSION="v4.19.1-pulumi.2"
+    MIGRATECLI_VERSION="v4.19.1-pulumi.3"
     INSTALL_DEST=${GOBIN:-$(go env GOPATH)/bin}
     mkdir -p "${INSTALL_DEST}"
     GOBIN="${INSTALL_DEST}" CGO_ENABLED=0 go install \

--- a/quickstart-docker-compose/scripts/migrate-db.sh
+++ b/quickstart-docker-compose/scripts/migrate-db.sh
@@ -21,11 +21,10 @@ which migrate >/dev/null || {
     echo "Building 'migrate' from source."
     # Pinned to match the pulumi/migrations container image; sync with the
     # service repo's migrations/Dockerfile and go.mod when bumping.
-    MIGRATECLI_VERSION="v4.13.2-0.20260317180800-e25d528f435d"
+    MIGRATECLI_VERSION="v4.19.1-pulumi.1"
     INSTALL_DEST=${GOBIN:-$(go env GOPATH)/bin}
     mkdir -p "${INSTALL_DEST}"
     GOBIN="${INSTALL_DEST}" CGO_ENABLED=0 go install \
-        -tags=mysql \
         -ldflags="-X main.Version=${MIGRATECLI_VERSION}" \
         "github.com/pulumi/golang-migrate/v4/cmd/migrate@${MIGRATECLI_VERSION}"
 

--- a/quickstart-docker-compose/scripts/migrate-db.sh
+++ b/quickstart-docker-compose/scripts/migrate-db.sh
@@ -21,7 +21,7 @@ which migrate >/dev/null || {
     echo "Building 'migrate' from source."
     # Pinned to match the pulumi/migrations container image; sync with the
     # service repo's migrations/Dockerfile and go.mod when bumping.
-    MIGRATECLI_VERSION="v4.19.1-pulumi.1"
+    MIGRATECLI_VERSION="v4.19.1-pulumi.2"
     INSTALL_DEST=${GOBIN:-$(go env GOPATH)/bin}
     mkdir -p "${INSTALL_DEST}"
     GOBIN="${INSTALL_DEST}" CGO_ENABLED=0 go install \


### PR DESCRIPTION
## Summary

Pulumi's `golang-migrate` fork synced to upstream `v4.19.1` and pruned to mysql-only ([pulumi/golang-migrate#17](https://github.com/pulumi/golang-migrate/pull/17)), tagged `v4.19.1-pulumi.1`. `mysql` and `source/file` are now imported unconditionally in `cmd/migrate/main.go`, so `-tags=mysql` is no longer needed to register them.

Part of a coordinated bump across `pulumi/golang-migrate`, `pulumi/pulumi-service`, and this repo. `pulumi-service`'s `scripts/check-migratecli-pin.py` (run in `make lint_migrations`) enforces that this script's pin matches `pulumi-service`'s `go.mod`/`MODULE.bazel`/`migrations/Dockerfile` — once this merges, `pulumi-service` bumps its submodule pointer to pick it up.

## Test plan

- [ ] `bash quickstart-docker-compose/scripts/migrate-db.sh` happy-path against a fresh local MySQL (binary not yet on PATH so the install path runs)