### PR TITLE
Bump pinned migratecli to v4.19.1-pulumi.4

### DIFF
--- a/quickstart-docker-compose/scripts/migrate-db.sh
+++ b/quickstart-docker-compose/scripts/migrate-db.sh
@@ -21,7 +21,7 @@ which migrate >/dev/null || {
     echo "Building 'migrate' from source."
     # Pinned to match the pulumi/migrations container image; sync with the
     # service repo's migrations/Dockerfile and go.mod when bumping.
-    MIGRATECLI_VERSION="v4.19.1-pulumi.3"
+    MIGRATECLI_VERSION="v4.19.1-pulumi.4"
     INSTALL_DEST=${GOBIN:-$(go env GOPATH)/bin}
     mkdir -p "${INSTALL_DEST}"
     GOBIN="${INSTALL_DEST}" CGO_ENABLED=0 go install \


### PR DESCRIPTION
## Summary
- Re-pins `MIGRATECLI_VERSION` in `quickstart-docker-compose/scripts/migrate-db.sh` to `v4.19.1-pulumi.4`, the newly tagged release of [pulumi/golang-migrate#23](https://github.com/pulumi/golang-migrate/pull/23), which clears outstanding security alerts and syncs mysql-driver deps on top of the fork.
- Mirrors the previous bump pattern from #1225/#1287 — this is a standalone pin bump, no other behavior changes.
- A parallel bump to the same version is staged in `pulumi-service` (branch `kmosher/migratecli-repin`) for `go.mod`, `MODULE.bazel`, and the migrations Dockerfile/scripts; that PR is separate and can be opened once this one merges, mirroring the established `cd76f89`/#1225 two-PR pattern for the submodule pointer bump.

## Test plan
- [ ] Confirm `go install github.com/pulumi/golang-migrate/v4/cmd/migrate@v4.19.1-pulumi.4` resolves and builds cleanly
- [ ] Run the quickstart docker-compose migration flow locally to confirm `migrate-db.sh` still builds/runs the pinned CLI correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FmJ7sekFDC9zYZrjAyL9xm
