### PR TITLE
ecs-hosted/go: honor consoleHideEmailSignup

### DIFF
--- a/ecs-hosted/go/application/service/consoleService.go
+++ b/ecs-hosted/go/application/service/consoleService.go
@@ -212,7 +212,7 @@ func newConsoleEnvironmentVariables(args *ConsoleContainerServiceArgs, lbDnsName
 		env = append(env, CreateEnvVar("PULUMI_HIDE_EMAIL_LOGIN", "true"))
 	}
 
-	if args.HideEmailLogin {
+	if args.HideEmailSignup {
 		env = append(env, CreateEnvVar("PULUMI_HIDE_EMAIL_SIGNUP", "true"))
 	}
 

--- a/ecs-hosted/go/application/service/consoleService_test.go
+++ b/ecs-hosted/go/application/service/consoleService_test.go
@@ -1,0 +1,64 @@
+package service
+
+import (
+	"testing"
+)
+
+// Absent and empty are different: the console treats an unset
+// PULUMI_HIDE_EMAIL_* as "show it".
+func envValue(env []map[string]any, name string) (string, bool) {
+	for _, e := range env {
+		if e["name"] == name {
+			value, ok := e["value"].(string)
+			if !ok {
+				return "", true
+			}
+			return value, true
+		}
+	}
+	return "", false
+}
+
+func assertHideVar(t *testing.T, env []map[string]any, name string, want bool) {
+	t.Helper()
+
+	value, present := envValue(env, name)
+	if present != want {
+		t.Errorf("%s present = %v, want %v", name, present, want)
+		return
+	}
+	if present && value != "true" {
+		t.Errorf("%s = %q, want %q", name, value, "true")
+	}
+}
+
+func TestConsoleEnvironmentVariablesEmailToggles(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		login      bool
+		signup     bool
+		wantLogin  bool
+		wantSignup bool
+	}{
+		{name: "neither set", login: false, signup: false, wantLogin: false, wantSignup: false},
+		{name: "login only", login: true, signup: false, wantLogin: true, wantSignup: false},
+		{name: "signup only", login: false, signup: true, wantLogin: false, wantSignup: true},
+		{name: "both set", login: true, signup: true, wantLogin: true, wantSignup: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			env := newConsoleEnvironmentVariables(&ConsoleContainerServiceArgs{
+				HideEmailLogin:  tt.login,
+				HideEmailSignup: tt.signup,
+			}, "")
+
+			assertHideVar(t, env, "PULUMI_HIDE_EMAIL_LOGIN", tt.wantLogin)
+			assertHideVar(t, env, "PULUMI_HIDE_EMAIL_SIGNUP", tt.wantSignup)
+		})
+	}
+}


### PR DESCRIPTION
`consoleHideEmailSignup` has never done anything on the ECS/Go installer, and `consoleHideEmailLogin` has been hiding email signup as a side effect.

`newConsoleEnvironmentVariables` emitted `PULUMI_HIDE_EMAIL_SIGNUP` from `args.HideEmailLogin`. Everything upstream of that conditional — `config.ConsoleHideEmailSignup` → `main.go` → `ConsoleContainerServiceArgs.HideEmailSignup` — was already correct, so the field was simply never read. `eks-hosted` and `ecs-hosted/ts` pass both values through correctly; the swap is confined to this one file.

## Upgrade note

This is a behavior change for existing ECS/Go stacks. An operator who set only `consoleHideEmailLogin: true` was getting email signup hidden too. After this fix, their next `pulumi up` makes email signup reappear — a self-hosted install could start accepting email signups it believed were disabled.

Anyone relying on that coupling should set `consoleHideEmailSignup: true` explicitly, which is what the README already documents it as doing.

## Test plan

- `cd ecs-hosted/go && go test ./application/service/...`
- The new table test covers all four flag combinations. Either flag alone reproduces one half of the bug: reverting the one-line fix fails `login_only` (signup hidden when it should not be) and `signup_only` (signup shown when it should be hidden).
- On a deployed stack, set `consoleHideEmailSignup: true` with `consoleHideEmailLogin` unset and confirm the console task definition carries `PULUMI_HIDE_EMAIL_SIGNUP=true` and no `PULUMI_HIDE_EMAIL_LOGIN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBxTRPiVkYbeR6SsZv1A6u
